### PR TITLE
feat(flant_gitops): use hclog for debug, change dev-mode setup

### DIFF
--- a/vault-plugins/flant_gitops/.gitignore
+++ b/vault-plugins/flant_gitops/.gitignore
@@ -1,1 +1,2 @@
 /vault/plugins/
+flant_gitops.log

--- a/vault-plugins/flant_gitops/Makefile
+++ b/vault-plugins/flant_gitops/Makefile
@@ -22,6 +22,10 @@ start:
 
 enable:
 	VAULT_ADDR='http://127.0.0.1:8200' vault secrets enable -path=flant-gitops vault-plugin-flant-gitops
+	VAULT_ADDR='http://127.0.0.1:8200' vault write flant-gitops/configure git_repo_url=https://github.com/flant/negentropy git_branch_name=flant_gitops_test_infra required_number_of_verified_signatures_on_commit=0 git_poll_period=1 last_successful_commit="" docker_image="alpine:3.14.0@sha256:234cb88d3020898631af0ccbbcca9a66ae7306ecd30c9720690858c1b007d2a0" command="flant_gitops.sh"
+
+	touch flant_gitops.log
+	tail -f flant_gitops.log
 
 clean:
 	rm -f ./vault/plugins/vault-plugin-flant-gitops


### PR DESCRIPTION
- Use hclog for debug logs, by default open log into file flant_gitops.log.
- Add fixture git repo https://github.com/flant/negentropy branch flant_gitops_test_infra by default in Makefile.