### PR TITLE
Subjects list in Group and RoleBinding

### DIFF
--- a/vault-plugins/.gitignore
+++ b/vault-plugins/.gitignore
@@ -1,6 +1,5 @@
 .idea
 .vscode
 node_modules
-tests/data/*
-build/*
-
+data
+build

--- a/vault-plugins/.golangci.yaml
+++ b/vault-plugins/.golangci.yaml
@@ -22,7 +22,7 @@ linters:
   - gci
   - gocritic
   - gofmt
-  - goimports
+  # - goimports
   - gofumpt
   # - golint
   - gosimple

--- a/vault-plugins/flant_iam/README.md
+++ b/vault-plugins/flant_iam/README.md
@@ -1,24 +1,34 @@
 # flant_iam
 
-The IAM module that manages tenants, projects, users, and roles.
+The IAM module.
 
 ## Development
 
-### Start vault
+Go to the path above, so you are in `vault-plugins` dir.
 
-To build the plugin, start vault in docker and register the 
-plugin: `./start.sh`. This script also populates test data.
+Exec
 
-### Run tests
-
-After `start.sh` is run, do
-
-```shell
-make deps 
-make test
+```sh
+flant_iam/tests/start.sh
 ```
 
-## Format
+To rebuild a module, run
 
-It would be wonderful if you run `make fmt` before pushing. 
-It reduces diff clutter and saves your time.
+```sh
+docker exec gobuild /gobuild.sh flant_iam
+```
+
+
+To mount updated module, run
+
+```sh
+docker exec dev-vault /remount.sh flant_iam
+```
+
+
+Run tests
+```sh
+cd flant_iam
+make deps
+make test
+```

--- a/vault-plugins/flant_iam/backend/parse.go
+++ b/vault-plugins/flant_iam/backend/parse.go
@@ -1,8 +1,11 @@
 package backend
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/vault/sdk/framework"
 
+	"github.com/flant/negentropy/vault-plugins/flant_iam/model"
 	"github.com/flant/negentropy/vault-plugins/flant_iam/uuid"
 )
 
@@ -19,4 +22,28 @@ func getCreationID(expectID bool, data *framework.FieldData) string {
 	}
 
 	return id
+}
+
+func parseSubjects(data *framework.FieldData) ([]model.SubjectNotation, error) {
+	subjects := make([]model.SubjectNotation, 0)
+
+	rawList := data.Get("subjects")
+	if rawList == nil {
+		return subjects, nil
+	}
+
+	rawSubjects, ok := rawList.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("cannot parse subjects list")
+	}
+
+	for _, raw := range rawSubjects {
+		s, ok := raw.(model.SubjectNotation)
+		if !ok {
+			return nil, fmt.Errorf("cannot parse subject %v", raw)
+		}
+		subjects = append(subjects, s)
+	}
+
+	return subjects, nil
 }

--- a/vault-plugins/flant_iam/backend/parse.go
+++ b/vault-plugins/flant_iam/backend/parse.go
@@ -38,11 +38,12 @@ func parseSubjects(data *framework.FieldData) ([]model.SubjectNotation, error) {
 	}
 
 	for _, raw := range rawSubjects {
-		s, ok := raw.(model.SubjectNotation)
+		s, ok := raw.(map[string]interface{})
 		if !ok {
 			return nil, fmt.Errorf("cannot parse subject %v", raw)
 		}
-		subjects = append(subjects, s)
+		subj := model.SubjectNotation{Type: s["type"].(string), ID: s["id"].(string)}
+		subjects = append(subjects, subj)
 	}
 
 	return subjects, nil

--- a/vault-plugins/flant_iam/backend/path_group.go
+++ b/vault-plugins/flant_iam/backend/path_group.go
@@ -83,11 +83,6 @@ func (b groupBackend) paths() []*framework.Path {
 					Description: "Subjects list",
 					Required:    true,
 				},
-				"service_accounts": {
-					Type:        framework.TypeCommaStringSlice,
-					Description: "Service account UUIDs",
-					Required:    true,
-				},
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.CreateOperation: &framework.PathOperation{

--- a/vault-plugins/flant_iam/backend/path_group.go
+++ b/vault-plugins/flant_iam/backend/path_group.go
@@ -42,19 +42,9 @@ func (b groupBackend) paths() []*framework.Path {
 					Description: "Identifier for humans and machines",
 					Required:    true,
 				},
-				"users": {
-					Type:        framework.TypeCommaStringSlice,
-					Description: "User UUIDs",
-					Required:    true,
-				},
-				"groups": {
-					Type:        framework.TypeCommaStringSlice,
-					Description: "Group UUIDs",
-					Required:    true,
-				},
-				"service_accounts": {
-					Type:        framework.TypeCommaStringSlice,
-					Description: "Service account UUIDs",
+				"subjects": {
+					Type:        framework.TypeSlice,
+					Description: "Subjects list",
 					Required:    true,
 				},
 			},
@@ -88,14 +78,9 @@ func (b groupBackend) paths() []*framework.Path {
 					Description: "Identifier for humans and machines",
 					Required:    true,
 				},
-				"users": {
-					Type:        framework.TypeCommaStringSlice,
-					Description: "User UUIDs",
-					Required:    true,
-				},
-				"groups": {
-					Type:        framework.TypeCommaStringSlice,
-					Description: "Group UUIDs",
+				"subjects": {
+					Type:        framework.TypeSlice,
+					Description: "Subjects list",
 					Required:    true,
 				},
 				"service_accounts": {
@@ -157,19 +142,9 @@ func (b groupBackend) paths() []*framework.Path {
 					Description: "Identifier for humans and machines",
 					Required:    true,
 				},
-				"users": {
-					Type:        framework.TypeCommaStringSlice,
-					Description: "User UUIDs",
-					Required:    true,
-				},
-				"groups": {
-					Type:        framework.TypeCommaStringSlice,
-					Description: "Group UUIDs",
-					Required:    true,
-				},
-				"service_accounts": {
-					Type:        framework.TypeCommaStringSlice,
-					Description: "Service account UUIDs",
+				"subjects": {
+					Type:        framework.TypeSlice,
+					Description: "Subjects list",
 					Required:    true,
 				},
 			},
@@ -219,14 +194,12 @@ func (b *groupBackend) handleCreate(expectID bool) framework.OperationFunc {
 		id := getCreationID(expectID, data)
 
 		group := &model.Group{
-			UUID:            id,
-			TenantUUID:      data.Get(model.TenantForeignPK).(string),
-			BuiltinType:     "",
-			Identifier:      data.Get("identifier").(string),
-			Users:           data.Get("users").([]string),
-			Groups:          data.Get("groups").([]string),
-			ServiceAccounts: data.Get("service_accounts").([]string),
-			Origin:          model.OriginIAM,
+			UUID:        id,
+			TenantUUID:  data.Get(model.TenantForeignPK).(string),
+			BuiltinType: "",
+			Identifier:  data.Get("identifier").(string),
+			Subjects:    data.Get("subjects").([]model.SubjectNotation),
+			Origin:      model.OriginIAM,
 		}
 
 		tx := b.storage.Txn(true)
@@ -251,15 +224,13 @@ func (b *groupBackend) handleUpdate() framework.OperationFunc {
 		id := data.Get("uuid").(string)
 
 		group := &model.Group{
-			UUID:            id,
-			TenantUUID:      data.Get(model.TenantForeignPK).(string),
-			Version:         data.Get("resource_version").(string),
-			Identifier:      data.Get("identifier").(string),
-			BuiltinType:     "",
-			Users:           data.Get("users").([]string),
-			Groups:          data.Get("groups").([]string),
-			ServiceAccounts: data.Get("service_accounts").([]string),
-			Origin:          model.OriginIAM,
+			UUID:        id,
+			TenantUUID:  data.Get(model.TenantForeignPK).(string),
+			Version:     data.Get("resource_version").(string),
+			Identifier:  data.Get("identifier").(string),
+			BuiltinType: "",
+			Subjects:    data.Get("subjects").([]model.SubjectNotation),
+			Origin:      model.OriginIAM,
 		}
 
 		tx := b.storage.Txn(true)

--- a/vault-plugins/flant_iam/backend/path_rolebinding.go
+++ b/vault-plugins/flant_iam/backend/path_rolebinding.go
@@ -243,14 +243,12 @@ func (b *roleBindingBackend) handleCreate(expectID bool) framework.OperationFunc
 		expiration := time.Now().Add(time.Duration(ttl) * time.Second).Unix()
 
 		roleBinding := &model.RoleBinding{
-			UUID:            id,
-			TenantUUID:      data.Get(model.TenantForeignPK).(string),
-			ValidTill:       expiration,
-			RequireMFA:      data.Get("require_mfa").(bool),
-			Users:           data.Get("users").([]string),
-			Groups:          data.Get("groups").([]string),
-			ServiceAccounts: data.Get("service_accounts").([]string),
-			Origin:          model.OriginIAM,
+			UUID:       id,
+			TenantUUID: data.Get(model.TenantForeignPK).(string),
+			ValidTill:  expiration,
+			RequireMFA: data.Get("require_mfa").(bool),
+			Subjects:   data.Get("subjects").([]model.SubjectNotation),
+			Origin:     model.OriginIAM,
 		}
 
 		tx := b.storage.Txn(true)
@@ -278,15 +276,13 @@ func (b *roleBindingBackend) handleUpdate() framework.OperationFunc {
 		expiration := time.Now().Add(time.Duration(ttl) * time.Second).Unix()
 
 		roleBinding := &model.RoleBinding{
-			UUID:            id,
-			TenantUUID:      data.Get(model.TenantForeignPK).(string),
-			Version:         data.Get("resource_version").(string),
-			ValidTill:       expiration,
-			RequireMFA:      data.Get("require_mfa").(bool),
-			Users:           data.Get("users").([]string),
-			Groups:          data.Get("groups").([]string),
-			ServiceAccounts: data.Get("service_accounts").([]string),
-			Origin:          model.OriginIAM,
+			UUID:       id,
+			TenantUUID: data.Get(model.TenantForeignPK).(string),
+			Version:    data.Get("resource_version").(string),
+			ValidTill:  expiration,
+			RequireMFA: data.Get("require_mfa").(bool),
+			Subjects:   data.Get("subjects").([]model.SubjectNotation),
+			Origin:     model.OriginIAM,
 		}
 
 		tx := b.storage.Txn(true)

--- a/vault-plugins/flant_iam/backend/path_rolebinding.go
+++ b/vault-plugins/flant_iam/backend/path_rolebinding.go
@@ -43,19 +43,9 @@ func (b roleBindingBackend) paths() []*framework.Path {
 					Description: "Identifier for humans and machines",
 					Required:    true,
 				},
-				"users": {
-					Type:        framework.TypeCommaStringSlice,
-					Description: "User UUIDs",
-					Required:    true,
-				},
-				"groups": {
-					Type:        framework.TypeCommaStringSlice,
-					Description: "Group UUIDs",
-					Required:    true,
-				},
-				"service_accounts": {
-					Type:        framework.TypeCommaStringSlice,
-					Description: "Service account UUIDs",
+				"subjects": {
+					Type:        framework.TypeSlice,
+					Description: "Subjects list",
 					Required:    true,
 				},
 				"ttl": {
@@ -94,19 +84,9 @@ func (b roleBindingBackend) paths() []*framework.Path {
 					Description: "ID of a tenant",
 					Required:    true,
 				},
-				"users": {
-					Type:        framework.TypeCommaStringSlice,
-					Description: "User UUIDs",
-					Required:    true,
-				},
-				"groups": {
-					Type:        framework.TypeCommaStringSlice,
-					Description: "Group UUIDs",
-					Required:    true,
-				},
-				"service_accounts": {
-					Type:        framework.TypeCommaStringSlice,
-					Description: "Service account UUIDs",
+				"subjects": {
+					Type:        framework.TypeSlice,
+					Description: "Subjects list",
 					Required:    true,
 				},
 				"ttl": {
@@ -168,19 +148,9 @@ func (b roleBindingBackend) paths() []*framework.Path {
 					Description: "Resource version",
 					Required:    true,
 				},
-				"users": {
-					Type:        framework.TypeCommaStringSlice,
-					Description: "User UUIDs",
-					Required:    true,
-				},
-				"groups": {
-					Type:        framework.TypeCommaStringSlice,
-					Description: "Group UUIDs",
-					Required:    true,
-				},
-				"service_accounts": {
-					Type:        framework.TypeCommaStringSlice,
-					Description: "Service account UUIDs",
+				"subjects": {
+					Type:        framework.TypeSlice,
+					Description: "Subjects list",
 					Required:    true,
 				},
 				"ttl": {

--- a/vault-plugins/flant_iam/backend/response.go
+++ b/vault-plugins/flant_iam/backend/response.go
@@ -70,19 +70,21 @@ func responseErr(req *logical.Request, err error) (*logical.Response, error) {
 	}
 }
 
+func responseErrMessage(req *logical.Request, message string, status int) (*logical.Response, error) {
+	rr := logical.ErrorResponse(message)
+	return logical.RespondWithStatusCode(rr, req, status)
+}
+
 func responseNotFound(req *logical.Request) (*logical.Response, error) {
-	rr := logical.ErrorResponse("not found")
-	return logical.RespondWithStatusCode(rr, req, http.StatusNotFound)
+	return responseErrMessage(req, "not found", http.StatusNotFound)
 }
 
 func responseBadVersion(req *logical.Request) (*logical.Response, error) {
-	rr := logical.ErrorResponse("bad version")
-	return logical.RespondWithStatusCode(rr, req, http.StatusConflict)
+	return responseErrMessage(req, "bad version", http.StatusConflict)
 }
 
 func responseBadOrigin(req *logical.Request) (*logical.Response, error) {
-	rr := logical.ErrorResponse("bad origin")
-	return logical.RespondWithStatusCode(rr, req, http.StatusForbidden)
+	return responseErrMessage(req, "bad origin", http.StatusForbidden)
 }
 
 // commit wraps the committing and error logging

--- a/vault-plugins/flant_iam/model/group.go
+++ b/vault-plugins/flant_iam/model/group.go
@@ -45,7 +45,6 @@ type Group struct {
 	UUID           GroupUUID  `json:"uuid"` // PK
 	TenantUUID     TenantUUID `json:"tenant_uuid"`
 	Version        string     `json:"resource_version"`
-	BuiltinType    string     `json:"-"`
 	Identifier     string     `json:"identifier"`
 	FullIdentifier string     `json:"full_identifier"`
 
@@ -72,9 +71,6 @@ func (u *Group) ObjId() string {
 func CalcGroupFullIdentifier(g *Group, tenant *Tenant) string {
 	name := g.Identifier
 	domain := "group." + tenant.Identifier
-	if g.BuiltinType != "" {
-		domain = g.BuiltinType + "." + domain
-	}
 	return name + "@" + domain
 }
 

--- a/vault-plugins/flant_iam/model/group.go
+++ b/vault-plugins/flant_iam/model/group.go
@@ -42,15 +42,17 @@ func GroupSchema() *memdb.DBSchema {
 }
 
 type Group struct {
-	UUID            GroupUUID            `json:"uuid"` // PK
-	TenantUUID      TenantUUID           `json:"tenant_uuid"`
-	Version         string               `json:"resource_version"`
-	BuiltinType     string               `json:"-"`
-	Identifier      string               `json:"identifier"`
-	FullIdentifier  string               `json:"full_identifier"`
-	Users           []UserUUID           `json:"users"`
-	Groups          []GroupUUID          `json:"groups"`
-	ServiceAccounts []ServiceAccountUUID `json:"service_accounts"`
+	UUID           GroupUUID  `json:"uuid"` // PK
+	TenantUUID     TenantUUID `json:"tenant_uuid"`
+	Version        string     `json:"resource_version"`
+	BuiltinType    string     `json:"-"`
+	Identifier     string     `json:"identifier"`
+	FullIdentifier string     `json:"full_identifier"`
+
+	Users           []UserUUID           `json:"-"`
+	Groups          []GroupUUID          `json:"-"`
+	ServiceAccounts []ServiceAccountUUID `json:"-"`
+	Subjects        []SubjectNotation    `json:"subjects"`
 
 	Origin ObjectOrigin `json:"origin"`
 
@@ -107,6 +109,8 @@ func (r *GroupRepository) Create(group *Group) error {
 	group.Version = NewResourceVersion()
 	group.FullIdentifier = CalcGroupFullIdentifier(group, tenant)
 
+	r.fillSubjects(group)
+
 	return r.save(group)
 }
 
@@ -148,7 +152,20 @@ func (r *GroupRepository) Update(group *Group) error {
 	}
 	group.FullIdentifier = CalcGroupFullIdentifier(group, tenant)
 
+	r.fillSubjects(group)
+
 	return r.save(group)
+}
+
+func (r *GroupRepository) fillSubjects(g *Group) error {
+	subj, err := NewSubjectsFetcher(r.db, g.Subjects).Fetch()
+	if err != nil {
+		return err
+	}
+	g.Groups = subj.Groups
+	g.ServiceAccounts = subj.ServiceAccounts
+	g.Users = subj.Users
+	return nil
 }
 
 /*

--- a/vault-plugins/flant_iam/model/group.go
+++ b/vault-plugins/flant_iam/model/group.go
@@ -105,7 +105,9 @@ func (r *GroupRepository) Create(group *Group) error {
 	group.Version = NewResourceVersion()
 	group.FullIdentifier = CalcGroupFullIdentifier(group, tenant)
 
-	r.fillSubjects(group)
+	if err := r.fillSubjects(group); err != nil {
+		return err
+	}
 
 	return r.save(group)
 }
@@ -148,7 +150,9 @@ func (r *GroupRepository) Update(group *Group) error {
 	}
 	group.FullIdentifier = CalcGroupFullIdentifier(group, tenant)
 
-	r.fillSubjects(group)
+	if err := r.fillSubjects(group); err != nil {
+		return err
+	}
 
 	return r.save(group)
 }

--- a/vault-plugins/flant_iam/model/ordering.go
+++ b/vault-plugins/flant_iam/model/ordering.go
@@ -32,6 +32,8 @@ func (snl *SubjectsFetcher) Fetch() (*Subjects, error) {
 		Groups:          make([]GroupUUID, 0),
 	}
 
+	seen := map[string]struct{}{}
+
 	for _, subj := range snl.entries {
 		switch subj.Type {
 		case ServiceAccountType:
@@ -39,18 +41,32 @@ func (snl *SubjectsFetcher) Fetch() (*Subjects, error) {
 			if err != nil {
 				return nil, err
 			}
+			if _, ok := seen[subj.ID]; ok {
+				continue
+			}
+			seen[subj.ID] = struct{}{}
 			result.ServiceAccounts = append(result.ServiceAccounts, sa.UUID)
+
 		case UserType:
 			u, err := NewUserRepository(snl.db).GetByID(subj.ID)
 			if err != nil {
 				return nil, err
 			}
+			if _, ok := seen[subj.ID]; ok {
+				continue
+			}
+			seen[subj.ID] = struct{}{}
 			result.Users = append(result.Users, u.UUID)
+
 		case GroupType:
 			g, err := NewGroupRepository(snl.db).GetByID(subj.ID)
 			if err != nil {
 				return nil, err
 			}
+			if _, ok := seen[subj.ID]; ok {
+				continue
+			}
+			seen[subj.ID] = struct{}{}
 			result.Groups = append(result.Groups, g.UUID)
 		}
 	}

--- a/vault-plugins/flant_iam/model/ordering.go
+++ b/vault-plugins/flant_iam/model/ordering.go
@@ -1,0 +1,59 @@
+package model
+
+import "github.com/flant/negentropy/vault-plugins/shared/io"
+
+type Subjects struct {
+	ServiceAccounts []ServiceAccountUUID
+	Users           []UserUUID
+	Groups          []GroupUUID
+}
+
+type SubjectNotation struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+type SubjectsFetcher struct {
+	db      *io.MemoryStoreTxn // called "db" not to provoke transaction semantics
+	entries []SubjectNotation
+}
+
+func NewSubjectsFetcher(db *io.MemoryStoreTxn, entries []SubjectNotation) *SubjectsFetcher {
+	return &SubjectsFetcher{
+		db:      db,
+		entries: entries,
+	}
+}
+
+func (snl *SubjectsFetcher) Fetch() (*Subjects, error) {
+	result := &Subjects{
+		ServiceAccounts: make([]ServiceAccountUUID, 0),
+		Users:           make([]UserUUID, 0),
+		Groups:          make([]GroupUUID, 0),
+	}
+
+	for _, subj := range snl.entries {
+		switch subj.Type {
+		case ServiceAccountType:
+			sa, err := NewServiceAccountRepository(snl.db).GetByID(subj.ID)
+			if err != nil {
+				return nil, err
+			}
+			result.ServiceAccounts = append(result.ServiceAccounts, sa.UUID)
+		case UserType:
+			u, err := NewUserRepository(snl.db).GetByID(subj.ID)
+			if err != nil {
+				return nil, err
+			}
+			result.Users = append(result.Users, u.UUID)
+		case GroupType:
+			g, err := NewGroupRepository(snl.db).GetByID(subj.ID)
+			if err != nil {
+				return nil, err
+			}
+			result.Groups = append(result.Groups, g.UUID)
+		}
+	}
+
+	return result, nil
+}

--- a/vault-plugins/flant_iam/model/rolebinding_test.go
+++ b/vault-plugins/flant_iam/model/rolebinding_test.go
@@ -1,7 +1,13 @@
 package model
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/flant/negentropy/vault-plugins/flant_iam/uuid"
+	"github.com/flant/negentropy/vault-plugins/shared/io"
+	"github.com/sethvargo/go-password/password"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_RoleBindingDbSchema(t *testing.T) {
@@ -9,4 +15,200 @@ func Test_RoleBindingDbSchema(t *testing.T) {
 	if err := schema.Validate(); err != nil {
 		t.Fatalf("role binding schema is invalid: %v", err)
 	}
+}
+
+type Model interface {
+	ObjType() string
+	ObjId() string
+}
+
+func toSubjectNotation(m Model) SubjectNotation {
+	return SubjectNotation{
+		Type: m.ObjType(),
+		ID:   m.ObjId(),
+	}
+}
+
+func toSubjectNotations(ms ...Model) []SubjectNotation {
+	sns := make([]SubjectNotation, 0)
+	for _, m := range ms {
+		sns = append(sns, toSubjectNotation(m))
+	}
+	return sns
+}
+
+func Test_RoleBindingOnCreationSubjectsCalculation(t *testing.T) {
+	testRoleBindingSubjectsCalculation(t, func(tx *io.MemoryStoreTxn, rb *RoleBinding) error {
+		return NewRoleBindingRepository(tx).Create(rb)
+	})
+}
+
+func Test_RoleBindingOnUpdateSubjectsCalculation(t *testing.T) {
+	testRoleBindingSubjectsCalculation(t, func(tx *io.MemoryStoreTxn, rb *RoleBinding) error {
+		return NewRoleBindingRepository(tx).Update(rb)
+	})
+}
+
+func testRoleBindingSubjectsCalculation(t *testing.T, action func(*io.MemoryStoreTxn, *RoleBinding) error) {
+	store, _ := initTestDB()
+	tx := store.Txn(true)
+
+	// Data
+	ten := genTenant(tx)
+	sa1 := genServiceAccount(tx, ten.UUID)
+	sa2 := genServiceAccount(tx, ten.UUID)
+	u1 := genUser(tx, ten.UUID)
+	u2 := genUser(tx, ten.UUID)
+	g1 := genGroup(tx, ten.UUID)
+	g2 := genGroup(tx, ten.UUID)
+
+	tests := []struct {
+		name       string
+		subjects   []Model
+		assertions func(*testing.T, *RoleBinding)
+	}{
+		{
+			name:     "no subjects",
+			subjects: []Model{},
+			assertions: func(t *testing.T, rb *RoleBinding) {
+				assert.Len(t, rb.ServiceAccounts, 0, "should contain no serviceaccounts")
+				assert.Len(t, rb.Users, 0, "should contain no users")
+				assert.Len(t, rb.Groups, 0, "should contain no groups")
+			},
+		},
+		{
+			name:     "single SA",
+			subjects: []Model{sa1},
+			assertions: func(t *testing.T, rb *RoleBinding) {
+				assert.Len(t, rb.ServiceAccounts, 1, "should contain 1 serviceaccount")
+				assert.Len(t, rb.Users, 0, "should contain no users")
+				assert.Len(t, rb.Groups, 0, "should contain no groups")
+				assert.Contains(t, rb.ServiceAccounts, sa1.UUID)
+			},
+		},
+		{
+			name:     "single user",
+			subjects: []Model{u1},
+			assertions: func(t *testing.T, rb *RoleBinding) {
+				assert.Len(t, rb.ServiceAccounts, 0, "should contain no serviceaccounts")
+				assert.Len(t, rb.Users, 1, "should contain 1 user")
+				assert.Len(t, rb.Groups, 0, "should contain no groups")
+				assert.Contains(t, rb.Users, u1.UUID)
+			},
+		},
+		{
+			name:     "single group",
+			subjects: []Model{g1},
+			assertions: func(t *testing.T, rb *RoleBinding) {
+				assert.Len(t, rb.ServiceAccounts, 0, "should contain no serviceaccounts")
+				assert.Len(t, rb.Users, 0, "should contain no users")
+				assert.Len(t, rb.Groups, 1, "should contain 1 group")
+				assert.Contains(t, rb.Groups, g1.UUID)
+			},
+		},
+		{
+			name:     "all by one",
+			subjects: []Model{g1, u1, sa1},
+			assertions: func(t *testing.T, rb *RoleBinding) {
+				assert.Len(t, rb.ServiceAccounts, 1, "should contain 1 serviceaccount")
+				assert.Len(t, rb.Users, 1, "should contain 1 user")
+				assert.Len(t, rb.Groups, 1, "should contain 1 group")
+				assert.Contains(t, rb.ServiceAccounts, sa1.UUID)
+				assert.Contains(t, rb.Users, u1.UUID)
+				assert.Contains(t, rb.Groups, g1.UUID)
+			},
+		},
+		{
+			name:     "keeps addition ordering",
+			subjects: []Model{sa1, g2, u1, sa2, u2, g1},
+			assertions: func(t *testing.T, rb *RoleBinding) {
+				assert.Len(t, rb.ServiceAccounts, 2, "should contain 2 serviceaccount")
+				assert.Len(t, rb.Users, 2, "should contain 2 user")
+				assert.Len(t, rb.Groups, 2, "should contain 2 group")
+
+				assert.Equal(t, rb.ServiceAccounts, []ServiceAccountUUID{sa1.UUID, sa2.UUID})
+				assert.Equal(t, rb.Groups, []GroupUUID{g2.UUID, g1.UUID})
+				assert.Equal(t, rb.Users, []UserUUID{u1.UUID, u2.UUID})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rb := &RoleBinding{
+				UUID:       uuid.New(),
+				TenantUUID: ten.UUID,
+				Origin:     OriginIAM,
+				Subjects:   toSubjectNotations(tt.subjects...),
+
+				ServiceAccounts: []ServiceAccountUUID{"nonsense"},
+				Users:           []ServiceAccountUUID{"nonsense"},
+				Groups:          []ServiceAccountUUID{"nonsense"},
+			}
+			if err := NewRoleBindingRepository(tx).Create(rb); err != nil {
+				t.Fatalf("cannot create: %v", err)
+			}
+
+			created, err := NewRoleBindingRepository(tx).GetByID(rb.UUID)
+			if err != nil {
+				t.Fatalf("cannot get: %v", err)
+			}
+
+			tt.assertions(t, created)
+		})
+	}
+}
+
+func initTestDB() (*io.MemoryStore, error) {
+	schema, err := mergeSchema()
+	if err != nil {
+		return nil, err
+	}
+	return io.NewMemoryStore(schema, nil)
+}
+
+func genTenant(tx *io.MemoryStoreTxn) *Tenant {
+	identifier, _ := password.Generate(10, 3, 3, false, true) // pretty random string
+	ten := &Tenant{
+		UUID:       uuid.New(),
+		Identifier: identifier,
+	}
+	err := NewTenantRepository(tx).Create(ten)
+	if err != nil {
+		panic(fmt.Sprintf("cannot create tenant: %v", err))
+	}
+	return ten
+}
+
+func genUser(tx *io.MemoryStoreTxn, tid TenantUUID) *User {
+	identifier, _ := password.Generate(10, 3, 3, false, true) // pretty random string
+	u := &User{
+		UUID:       uuid.New(),
+		TenantUUID: tid,
+		Origin:     OriginIAM,
+		Identifier: identifier,
+	}
+	err := NewUserRepository(tx).Create(u)
+	if err != nil {
+		panic(fmt.Sprintf("cannot create user: %v", err))
+	}
+	return u
+}
+
+func genServiceAccount(tx *io.MemoryStoreTxn, tid TenantUUID) *ServiceAccount {
+	sa := &ServiceAccount{UUID: uuid.New(), TenantUUID: tid, Origin: OriginIAM}
+	err := NewServiceAccountRepository(tx).Create(sa)
+	if err != nil {
+		panic(fmt.Sprintf("cannot create serviceaccount: %v", err))
+	}
+	return sa
+}
+
+func genGroup(tx *io.MemoryStoreTxn, tid TenantUUID) *Group {
+	g := &Group{UUID: uuid.New(), TenantUUID: tid, Origin: OriginIAM}
+	err := NewGroupRepository(tx).Create(g)
+	if err != nil {
+		panic(fmt.Sprintf("cannot create group: %v", err))
+	}
+	return g
 }

--- a/vault-plugins/flant_iam/model/rolebinding_test.go
+++ b/vault-plugins/flant_iam/model/rolebinding_test.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/flant/negentropy/vault-plugins/flant_iam/uuid"
-	"github.com/flant/negentropy/vault-plugins/shared/io"
 	"github.com/sethvargo/go-password/password"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flant/negentropy/vault-plugins/flant_iam/uuid"
+	"github.com/flant/negentropy/vault-plugins/shared/io"
 )
 
 func Test_RoleBindingDbSchema(t *testing.T) {

--- a/vault-plugins/flant_iam/openapi.json
+++ b/vault-plugins/flant_iam/openapi.json
@@ -1173,30 +1173,16 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "groups": {
-                    "type": "array",
-                    "description": "Group UUIDs",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
                   "identifier": {
                     "type": "string",
                     "description": "Identifier for humans and machines",
                     "pattern": "\\w([\\w-.]*\\w)?"
                   },
-                  "service_accounts": {
+                  "subjects": {
                     "type": "array",
-                    "description": "Service account UUIDs",
+                    "description": "Subjects list",
                     "items": {
-                      "type": "string"
-                    }
-                  },
-                  "users": {
-                    "type": "array",
-                    "description": "User UUIDs",
-                    "items": {
-                      "type": "string"
+                      "type": "object"
                     }
                   },
                   "uuid": {
@@ -1207,9 +1193,7 @@
                 },
                 "required": [
                   "identifier",
-                  "users",
-                  "groups",
-                  "service_accounts",
+                  "subjects",
                   "uuid"
                 ]
               }
@@ -1270,13 +1254,6 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "groups": {
-                    "type": "array",
-                    "description": "Group UUIDs",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
                   "identifier": {
                     "type": "string",
                     "description": "Identifier for humans and machines",
@@ -1286,27 +1263,18 @@
                     "type": "string",
                     "description": "Resource version"
                   },
-                  "service_accounts": {
+                  "subjects": {
                     "type": "array",
-                    "description": "Service account UUIDs",
+                    "description": "Subjects list",
                     "items": {
-                      "type": "string"
-                    }
-                  },
-                  "users": {
-                    "type": "array",
-                    "description": "User UUIDs",
-                    "items": {
-                      "type": "string"
+                      "type": "object"
                     }
                   }
                 },
                 "required": [
-                  "groups",
-                  "service_accounts",
+                  "subjects",
                   "resource_version",
-                  "identifier",
-                  "users"
+                  "identifier"
                 ]
               }
             }
@@ -1565,35 +1533,21 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "groups": {
-                    "type": "array",
-                    "description": "Group UUIDs",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
                   "require_mfa": {
                     "type": "boolean",
                     "description": "Requires multi-factor authentication"
                   },
-                  "service_accounts": {
+                  "subjects": {
                     "type": "array",
-                    "description": "Service account UUIDs",
+                    "description": "Subjects list",
                     "items": {
-                      "type": "string"
+                      "type": "object"
                     }
                   },
                   "ttl": {
                     "type": "integer",
                     "description": "TTL in seconds",
                     "format": "seconds"
-                  },
-                  "users": {
-                    "type": "array",
-                    "description": "User UUIDs",
-                    "items": {
-                      "type": "string"
-                    }
                   },
                   "uuid": {
                     "type": "string",
@@ -1603,9 +1557,7 @@
                 },
                 "required": [
                   "uuid",
-                  "users",
-                  "groups",
-                  "service_accounts",
+                  "subjects",
                   "ttl",
                   "require_mfa"
                 ]
@@ -1667,13 +1619,6 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "groups": {
-                    "type": "array",
-                    "description": "Group UUIDs",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
                   "require_mfa": {
                     "type": "boolean",
                     "description": "Requires multi-factor authentication"
@@ -1682,33 +1627,24 @@
                     "type": "string",
                     "description": "Resource version"
                   },
-                  "service_accounts": {
+                  "subjects": {
                     "type": "array",
-                    "description": "Service account UUIDs",
+                    "description": "Subjects list",
                     "items": {
-                      "type": "string"
+                      "type": "object"
                     }
                   },
                   "ttl": {
                     "type": "integer",
                     "description": "TTL in seconds",
                     "format": "seconds"
-                  },
-                  "users": {
-                    "type": "array",
-                    "description": "User UUIDs",
-                    "items": {
-                      "type": "string"
-                    }
                   }
                 },
                 "required": [
-                  "users",
-                  "groups",
-                  "service_accounts",
+                  "resource_version",
+                  "subjects",
                   "ttl",
-                  "require_mfa",
-                  "resource_version"
+                  "require_mfa"
                 ]
               }
             }
@@ -1824,11 +1760,11 @@
                   }
                 },
                 "required": [
-                  "allowed_cidrs",
                   "token_ttl",
                   "token_max_ttl",
                   "uuid",
-                  "identifier"
+                  "identifier",
+                  "allowed_cidrs"
                 ]
               }
             }
@@ -1945,6 +1881,110 @@
         }
       }
     },
+    "/flant_iam/tenant/{tenant_uuid}/service_account/{owner_uuid}/password": {
+      "parameters": [
+        {
+          "name": "owner_uuid",
+          "description": "ID of the tenant service account",
+          "in": "path",
+          "schema": {
+            "type": "string",
+            "pattern": "\\w([\\w-.]*\\w)?"
+          },
+          "required": true
+        },
+        {
+          "name": "tenant_uuid",
+          "description": "ID of a tenant",
+          "in": "path",
+          "schema": {
+            "type": "string",
+            "pattern": "\\w([\\w-.]*\\w)?"
+          },
+          "required": true
+        }
+      ],
+      "get": {
+        "summary": "List password IDs",
+        "operationId": "getFlant_iamTenantTenant_uuidService_accountOwner_uuidPassword",
+        "tags": [
+          "secrets"
+        ],
+        "parameters": [
+          {
+            "name": "list",
+            "description": "Return a list if `true`",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/flant_iam/tenant/{tenant_uuid}/service_account/{owner_uuid}/password/{uuid}": {
+      "parameters": [
+        {
+          "name": "owner_uuid",
+          "description": "ID of the tenant service account",
+          "in": "path",
+          "schema": {
+            "type": "string",
+            "pattern": "\\w([\\w-.]*\\w)?"
+          },
+          "required": true
+        },
+        {
+          "name": "tenant_uuid",
+          "description": "ID of a tenant",
+          "in": "path",
+          "schema": {
+            "type": "string",
+            "pattern": "\\w([\\w-.]*\\w)?"
+          },
+          "required": true
+        },
+        {
+          "name": "uuid",
+          "description": "ID of a password",
+          "in": "path",
+          "schema": {
+            "type": "string",
+            "pattern": "\\w([\\w-.]*\\w)?"
+          },
+          "required": true
+        }
+      ],
+      "get": {
+        "summary": "Get password by ID",
+        "operationId": "getFlant_iamTenantTenant_uuidService_accountOwner_uuidPasswordUuid",
+        "tags": [
+          "secrets"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete password by ID",
+        "operationId": "deleteFlant_iamTenantTenant_uuidService_accountOwner_uuidPasswordUuid",
+        "tags": [
+          "secrets"
+        ],
+        "responses": {
+          "204": {
+            "description": "empty body"
+          }
+        }
+      }
+    },
     "/flant_iam/tenant/{tenant_uuid}/service_account/{uuid}": {
       "parameters": [
         {
@@ -2020,11 +2060,11 @@
                   }
                 },
                 "required": [
-                  "token_ttl",
                   "token_max_ttl",
                   "resource_version",
                   "identifier",
-                  "allowed_cidrs"
+                  "allowed_cidrs",
+                  "token_ttl"
                 ]
               }
             }
@@ -2123,8 +2163,8 @@
                   }
                 },
                 "required": [
-                  "uuid",
-                  "identifier"
+                  "identifier",
+                  "uuid"
                 ]
               }
             }

--- a/vault-plugins/flant_iam/tests/start.sh
+++ b/vault-plugins/flant_iam/tests/start.sh
@@ -8,6 +8,7 @@ fi
 set -eo pipefail
 
 if [[ "${ci_mode}x" == "x" ]]; then
+  # NOT CI
   set -x
 
   # pushd ..
@@ -15,9 +16,9 @@ if [[ "${ci_mode}x" == "x" ]]; then
 
   # rm -rf ../build/*
   # pushd ../..
-  bash ../../dev-build.sh flant_iam
-  mkdir -p ../build
-  cp ../../build/flant_iam ../build/flant_iam
+  # bash ../../dev-build.sh flant_iam
+  mkdir -p build
+  # cp ../../build/flant_iam ../build/flant_iam
 
   # popd
 
@@ -35,13 +36,14 @@ id=$(docker run \
   -e VAULT_TOKEN=root \
   -e VAULT_LOG_LEVEL=debug \
   -e VAULT_DEV_ROOT_TOKEN_ID=root \
-  -v "$(pwd)/../build:/vault/plugins" \
+  -v "$(pwd)/build:/vault/plugins" \
   -v "$(pwd)/data:/vault/testdata" \
   vault:1.7.1 \
   server -dev -dev-plugin-dir=/vault/plugins)
 
 echo "Sleep a second or more ..." && sleep 5 # TODO(nabokihms): use container healthchecks
 if [[ "${ci_mode}x" != "x" ]]; then
+  # IN CI
   docker logs dev-vault 2>&1
 fi
 
@@ -51,8 +53,32 @@ vault secrets enable -path=flant_iam flant_iam \
 "
 
 if [[ "${ci_mode}x" == "x" ]]; then
+  # NOT CI
+
+  # USAGE:   docker exec dev-vault /remount.sh flant_iam
+  remount_script='#!/bin/sh\nvault plugin deregister $1 && vault plugin register -sha256=$(sha256sum /vault/plugins/$1 | cut -d" " -f1) $1 && vault plugin reload -mounts=$1/'
+  docker exec dev-vault sh -c "echo -e '$remount_script' > /remount.sh && chmod +x /remount.sh"
+
+  # USAGE:   docker exec gobuild /gobuild.sh flant_iam
+  docker run --rm -d --name gobuild \
+    -w /go/src/app \
+    -v "$PWD/build:/src/build" \
+    -v "$PWD/flant_iam:/go/src/app/flant_iam" \
+    -v "$PWD/flant_iam_auth:/go/src/app/flant_iam_auth" \
+    -v "$PWD/flant_gitopts:/go/src/app/flant_gitopts" \
+    -v "$PWD/shared:/go/src/app/shared" \
+    -v /tmp/vault-build:/go/pkg/mod \
+    -e CGO_ENABLED=1 \
+    tetafro/golang-gcc:1.16-alpine \
+    sh -c "echo -e '#!/bin/sh\ncd \$1 && go build -tags musl -o /src/build/\$1 cmd/\$1/main.go' > /gobuild.sh && chmod +x /gobuild.sh && sleep infinity"
+
+  docker exec gobuild /gobuild.sh flant_iam
+  docker exec dev-vault /remount.sh flant_iam
+
+  # See logs
   docker logs -f dev-vault
 fi
+
 # docker exec -it dev-vault sh
 
 # make enable
@@ -60,18 +86,6 @@ fi
 # vault read flant_iam/tenant/bcfa63ba-41fd-d33b-c13e-ef03daed0aa2
 
 # BIG HELPERS
-
-# docker run --rm -d --name gobuild \
-#     -w /go/src/app \
-#     -v "$PWD/build:/src/build" \
-#     -v "$PWD/flant_iam:/go/src/app/flant_iam" \
-#     -v "$PWD/flant_iam_auth:/go/src/app/flant_iam_auth" \
-#     -v "$PWD/flant_gitopts:/go/src/app/flant_gitopts" \
-#     -v "$PWD/shared:/go/src/app/shared" \
-#     -v /tmp/vault-build:/go/pkg/mod \
-#     -e CGO_ENABLED=1 \
-#     tetafro/golang-gcc:1.16-alpine \
-#     sh -c "echo -e '#!/bin/sh\ncd \$1 && go build -tags musl -o /src/build/\$1 cmd/\$1/main.go' > /gobuild.sh && chmod +x /gobuild.sh && sleep infinity"
 
 # docker exec gobuild /gobuild.sh flant_iam
 # docker exec dev-vault vault plugin reload -mounts=flant_iam/

--- a/vault-plugins/flant_iam/tests/start.sh
+++ b/vault-plugins/flant_iam/tests/start.sh
@@ -76,3 +76,4 @@ fi
 # docker exec gobuild /gobuild.sh flant_iam
 # docker exec dev-vault vault plugin reload -mounts=flant_iam/
 # docker exec dev-vault vault plugin reload -plugin flant_iam
+# vault plugin deregister flant_iam && vault plugin register  -sha256=$(sha256sum /vault/plugins/flant_iam | cut -d' ' -f1) flant_iam && vault plugin reload -mounts=flant_iam/

--- a/vault-plugins/flant_iam/tests/tests/07_role.mjs
+++ b/vault-plugins/flant_iam/tests/tests/07_role.mjs
@@ -126,7 +126,10 @@ describe("Role", function () {
         const { data: read } = await root.read(name)
         const role = read.data
 
-        expect(role).to.deep.eq({ ...payload, name, included_roles : null }, "payload must be saved")
+        expect(role).to.deep.eq(
+            { ...payload, name, included_roles: null },
+            "payload must be saved",
+        )
     })
 
     it("can be deleted", async () => {

--- a/vault-plugins/flant_iam/tests/tests/lib/subtenant.mjs
+++ b/vault-plugins/flant_iam/tests/tests/lib/subtenant.mjs
@@ -145,18 +145,14 @@ export function genProjectPayload(override = {}) {
 export function genGroupPayload(override = {}) {
     return {
         identifier: Faker.lorem.word(),
-        users: [],
-        groups: [],
-        service_accounts: [],
+        subjects: [],
         ...override,
     }
 }
 
 export function genRoleBindingPayload(override = {}) {
     return {
-        users: [],
-        groups: [],
-        service_accounts: [],
+        subjects: [],
         ttl: Faker.datatype.number(),
         require_mfa: Math.random() > 0.5,
         ...override,


### PR DESCRIPTION
HTTP API change. Dedicated subjects notation allows users to keep the desired sorting in Groups and Rolebindings. Istead of separate lists of service accounts, users and groups, API accepts and returns subjects as single list.


Note that empty subjects array is not allowed. It will result in error code 400.

```
// in rolebinding or group payload
{
  ...
  subjects: [
    { "type: "group", "id": "ggg" },
    { "type: "service_account", "id": "sasa" },
    { "type: "user", "id": "uuu" },
  ]
}
```