### PR TITLE
Feat check sharing and check group for role

### DIFF
--- a/vault-plugins/flant_iam/model/group_test.go
+++ b/vault-plugins/flant_iam/model/group_test.go
@@ -32,15 +32,15 @@ var (
 	group3 = Group{
 		UUID:            groupUUID3,
 		TenantUUID:      tenantUUID2,
-		Users:           []string{userUUID3, userUUID4},
-		ServiceAccounts: []string{serviceAccountUUID1},
+		Users:           []string{userUUID5},
+		ServiceAccounts: []string{serviceAccountUUID4},
 		Origin:          OriginIAM,
 	}
 	group4 = Group{
 		UUID:            groupUUID4,
 		TenantUUID:      tenantUUID1,
 		Users:           []string{userUUID2, userUUID3},
-		Groups:          []string{groupUUID2, groupUUID3},
+		Groups:          []string{groupUUID2},
 		ServiceAccounts: []string{serviceAccountUUID2, serviceAccountUUID3},
 		Origin:          OriginIAM,
 	}

--- a/vault-plugins/flant_iam/model/identitysharing_test.go
+++ b/vault-plugins/flant_iam/model/identitysharing_test.go
@@ -1,0 +1,81 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/flant/negentropy/vault-plugins/shared/io"
+)
+
+const (
+	shareUUID1 = "00000000-0000-0000-0000-010000000000"
+	shareUUID2 = "00000000-0000-0000-0000-020000000000"
+)
+
+var (
+	share1 = IdentitySharing{
+		UUID:                  shareUUID1,
+		SourceTenantUUID:      tenantUUID1,
+		DestinationTenantUUID: tenantUUID2,
+		Groups:                []string{groupUUID2},
+	}
+	share2 = IdentitySharing{
+		UUID:                  shareUUID2,
+		SourceTenantUUID:      tenantUUID2,
+		DestinationTenantUUID: tenantUUID1,
+		Groups:                []string{groupUUID3},
+	}
+)
+
+func createIdentitySharings(t *testing.T, repo *IdentitySharingRepository, shares ...IdentitySharing) {
+	for _, share := range shares {
+		tmp := share
+		err := repo.Create(&tmp)
+		dieOnErr(t, err)
+	}
+}
+
+func identitySharingFixture(t *testing.T, store *io.MemoryStore) {
+	shs := []IdentitySharing{share1, share2}
+	tx := store.Txn(true)
+	repo := NewIdentitySharingRepository(tx)
+	createIdentitySharings(t, repo, shs...)
+	err := tx.Commit()
+	dieOnErr(t, err)
+}
+
+func Test_IdentitySharingDbSchema(t *testing.T) {
+	schema := IdentitySharingSchema()
+	if err := schema.Validate(); err != nil {
+		t.Fatalf("identity sharing schema is invalid: %v", err)
+	}
+}
+
+func Test_ListIdentitySharing(t *testing.T) {
+	tx := runFixtures(t, tenantFixture, userFixture, serviceAccountFixture, groupFixture,
+		identitySharingFixture).Txn(true)
+	repo := NewIdentitySharingRepository(tx)
+
+	shares, err := repo.List(tenantUUID1)
+
+	dieOnErr(t, err)
+	ids := make([]string, 0)
+	for _, obj := range shares {
+		ids = append(ids, obj.ObjId())
+	}
+	checkDeepEqual(t, []string{shareUUID1}, ids)
+}
+
+func Test_ListForDestinationTenant(t *testing.T) {
+	tx := runFixtures(t, tenantFixture, userFixture, serviceAccountFixture, groupFixture,
+		identitySharingFixture).Txn(true)
+	repo := NewIdentitySharingRepository(tx)
+
+	shares, err := repo.ListForDestinationTenant(tenantUUID1)
+
+	dieOnErr(t, err)
+	ids := make([]string, 0)
+	for _, obj := range shares {
+		ids = append(ids, obj.ObjId())
+	}
+	checkDeepEqual(t, []string{shareUUID2}, ids)
+}

--- a/vault-plugins/flant_iam/model/rolebinding_test.go
+++ b/vault-plugins/flant_iam/model/rolebinding_test.go
@@ -28,7 +28,7 @@ var (
 		ValidTill:       100,
 		RequireMFA:      false,
 		Users:           []string{userUUID1, userUUID2},
-		Groups:          []string{groupUUID2, groupUUID3},
+		Groups:          []string{groupUUID2},
 		ServiceAccounts: []string{serviceAccountUUID1},
 		AnyProject:      false,
 		Projects:        []ProjectUUID{projectUUID1, projectUUID3},
@@ -43,7 +43,8 @@ var (
 		TenantUUID: tenantUUID2,
 		ValidTill:  110,
 		RequireMFA: false,
-		Users:      []string{userUUID1, userUUID2},
+		Users:      []string{userUUID5},
+		Groups:     []string{groupUUID3},
 		AnyProject: true,
 		Projects:   nil,
 		Roles: []BoundRole{{
@@ -352,7 +353,7 @@ func Test_FindDirectRoleBindingsForTenantGroups(t *testing.T) {
 		roleBindingFixture).Txn(true)
 	repo := NewRoleBindingRepository(tx)
 
-	rbsMap, err := repo.FindDirectRoleBindingsForTenantGroups(tenantUUID1, groupUUID2, groupUUID3)
+	rbsMap, err := repo.FindDirectRoleBindingsForTenantGroups(tenantUUID1, groupUUID2, groupUUID1)
 
 	dieOnErr(t, err)
 	checkDeepEqual(t, map[string]struct{}{rbUUID1: {}, rbUUID3: {}}, roleBindingsUUIDsFromMap(rbsMap))

--- a/vault-plugins/flant_iam/model/roleresolver.go
+++ b/vault-plugins/flant_iam/model/roleresolver.go
@@ -1,5 +1,7 @@
 package model
 
+import "fmt"
+
 type RoleResolver interface {
 	IsUserSharedWith(TenantUUID) (bool, error)
 	IsServiceAccountSharedWith(TenantUUID) (bool, error)

--- a/vault-plugins/flant_iam/model/roleresolver.go
+++ b/vault-plugins/flant_iam/model/roleresolver.go
@@ -1,7 +1,5 @@
 package model
 
-import "fmt"
-
 type RoleResolver interface {
 	IsUserSharedWith(TenantUUID) (bool, error)
 	IsServiceAccountSharedWith(TenantUUID) (bool, error)

--- a/vault-plugins/flant_iam/model/roleresolver.go
+++ b/vault-plugins/flant_iam/model/roleresolver.go
@@ -1,8 +1,10 @@
 package model
 
+import "github.com/flant/negentropy/vault-plugins/shared/io"
+
 type RoleResolver interface {
-	IsUserSharedWith(TenantUUID) (bool, error)
-	IsServiceAccountSharedWith(TenantUUID) (bool, error)
+	IsUserSharedWithTenant(*User, TenantUUID) (bool, error)
+	IsServiceAccountSharedWithTenant(*ServiceAccount, TenantUUID) (bool, error)
 
 	CheckUserForProjectScopedRole(UserUUID, RoleName, TenantUUID, ProjectUUID) (bool, RoleBindingParams, error)
 	CheckUserForTenantScopedRole(UserUUID, RoleName, TenantUUID) (bool, RoleBindingParams, error)
@@ -45,20 +47,56 @@ type RoleBindingsInformer interface {
 	FindDirectRoleBindingsForRoles(TenantUUID, ...RoleName) (map[RoleBindingUUID]*RoleBinding, error)
 }
 
+type SharingInformer interface {
+	ListForDestinationTenant(tenantID TenantUUID) ([]*IdentitySharing, error)
+}
+
 type roleResolver struct {
 	ri  RoleInformer
 	gi  GroupInformer
 	rbi RoleBindingsInformer
+	si  SharingInformer
 }
 
 var emptyRoleBindingParams = RoleBindingParams{}
 
-func (r *roleResolver) IsUserSharedWith(TenantUUID) (bool, error) {
-	panic("implement me")
+func (r *roleResolver) IsUserSharedWithTenant(user *User, destinationTenantUUID TenantUUID) (bool, error) {
+	shares, err := r.si.ListForDestinationTenant(destinationTenantUUID)
+	if err != nil {
+		return false, err
+	}
+	sourceTenantGroups, err := r.gi.FindAllParentGroupsForUserUUID(user.TenantUUID, user.UUID)
+	if err != nil {
+		return false, err
+	}
+	for i := range shares {
+		for _, sharedGroupUUID := range shares[i].Groups {
+			if _, isShared := sourceTenantGroups[sharedGroupUUID]; isShared {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
-func (r *roleResolver) IsServiceAccountSharedWith(TenantUUID) (bool, error) {
-	panic("implement me")
+func (r *roleResolver) IsServiceAccountSharedWithTenant(serviceAccount *ServiceAccount, destinationTenantUUID TenantUUID) (
+	bool, error) {
+	shares, err := r.si.ListForDestinationTenant(destinationTenantUUID)
+	if err != nil {
+		return false, err
+	}
+	sourceTenantGroups, err := r.gi.FindAllParentGroupsForServiceAccountUUID(serviceAccount.TenantUUID, serviceAccount.UUID)
+	if err != nil {
+		return false, err
+	}
+	for i := range shares {
+		for _, sharedGroupUUID := range shares[i].Groups {
+			if _, isShared := sourceTenantGroups[sharedGroupUUID]; isShared {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 func (r *roleResolver) collectAllRolesAndRoleBindings(tenantUUID TenantUUID,
@@ -362,10 +400,11 @@ func (r *roleResolver) CheckGroupForRole(groupUUID GroupUUID, roleName RoleName)
 	return false, err
 }
 
-func NewRoleResolver(ri RoleInformer, gi GroupInformer, rbi RoleBindingsInformer) RoleResolver {
+func NewRoleResolver(tx *io.MemoryStoreTxn) RoleResolver {
 	return &roleResolver{
-		ri:  ri,
-		gi:  gi,
-		rbi: rbi,
+		ri:  NewRoleRepository(tx),
+		gi:  NewGroupRepository(tx),
+		rbi: NewRoleBindingRepository(tx),
+		si:  NewIdentitySharingRepository(tx),
 	}
 }

--- a/vault-plugins/flant_iam/model/roleresolver_test.go
+++ b/vault-plugins/flant_iam/model/roleresolver_test.go
@@ -160,3 +160,33 @@ func Test_FindSubjectsWithTenantScopedRole(t *testing.T) {
 	checkDeepEqual(t, map[string]struct{}{userUUID1: {}, userUUID2: {}, userUUID3: {}, userUUID4: {}}, stringSet(users))
 	checkDeepEqual(t, map[string]struct{}{serviceAccountUUID1: {}, serviceAccountUUID2: {}, serviceAccountUUID3: {}}, stringSet(serviceAccounts))
 }
+
+func Test_CheckGroupForRole(t *testing.T) {
+	tx := runFixtures(t, tenantFixture, userFixture, serviceAccountFixture, groupFixture, roleFixture, projectFixture,
+		roleBindingFixture).Txn(true)
+	rr := roleResolver{
+		ri:  NewRoleRepository(tx),
+		gi:  NewGroupRepository(tx),
+		rbi: NewRoleBindingRepository(tx),
+	}
+
+	hasRole, err := rr.CheckGroupForRole(groupUUID2, roleName1)
+
+	dieOnErr(t, err)
+	checkDeepEqual(t, true, hasRole)
+}
+
+func Test_CheckGroupForRoleNegative(t *testing.T) {
+	tx := runFixtures(t, tenantFixture, userFixture, serviceAccountFixture, groupFixture, roleFixture, projectFixture,
+		roleBindingFixture).Txn(true)
+	rr := roleResolver{
+		ri:  NewRoleRepository(tx),
+		gi:  NewGroupRepository(tx),
+		rbi: NewRoleBindingRepository(tx),
+	}
+
+	hasRole, err := rr.CheckGroupForRole(groupUUID2, roleName4)
+
+	dieOnErr(t, err)
+	checkDeepEqual(t, false, hasRole)
+}

--- a/vault-plugins/flant_iam/model/roleresolver_test.go
+++ b/vault-plugins/flant_iam/model/roleresolver_test.go
@@ -124,8 +124,9 @@ func Test_FindSubjectsWithProjectScopedRole(t *testing.T) {
 	users, serviceAccounts, err := rr.FindSubjectsWithProjectScopedRole(roleName1, tenantUUID1, projectUUID3)
 
 	dieOnErr(t, err)
-	checkDeepEqual(t, map[string]struct{}{userUUID1: {}, userUUID2: {}, userUUID3: {}, userUUID4: {}}, stringSet(users))
-	checkDeepEqual(t, map[string]struct{}{serviceAccountUUID1: {}, serviceAccountUUID2: {}}, stringSet(serviceAccounts))
+	checkDeepEqual(t, map[string]struct{}{userUUID1: {}, userUUID2: {}, userUUID3: {}, userUUID5: {}}, stringSet(users))
+	checkDeepEqual(t, map[string]struct{}{serviceAccountUUID1: {}, serviceAccountUUID2: {}, serviceAccountUUID4: {}},
+		stringSet(serviceAccounts))
 }
 
 func Test_FindSubjectsWithTenantScopedRole(t *testing.T) {
@@ -136,8 +137,9 @@ func Test_FindSubjectsWithTenantScopedRole(t *testing.T) {
 	users, serviceAccounts, err := rr.FindSubjectsWithTenantScopedRole(roleName9, tenantUUID1)
 
 	dieOnErr(t, err)
-	checkDeepEqual(t, map[string]struct{}{userUUID1: {}, userUUID2: {}, userUUID3: {}, userUUID4: {}}, stringSet(users))
-	checkDeepEqual(t, map[string]struct{}{serviceAccountUUID1: {}, serviceAccountUUID2: {}, serviceAccountUUID3: {}}, stringSet(serviceAccounts))
+	checkDeepEqual(t, map[string]struct{}{userUUID1: {}, userUUID2: {}, userUUID3: {}}, stringSet(users))
+	checkDeepEqual(t, map[string]struct{}{serviceAccountUUID2: {}, serviceAccountUUID3: {}},
+		stringSet(serviceAccounts))
 }
 
 func Test_CheckGroupForRole(t *testing.T) {
@@ -160,4 +162,26 @@ func Test_CheckGroupForRoleNegative(t *testing.T) {
 
 	dieOnErr(t, err)
 	checkDeepEqual(t, false, hasRole)
+}
+
+func Test_IsUserSharedWithTenant(t *testing.T) {
+	tx := runFixtures(t, tenantFixture, userFixture, serviceAccountFixture, groupFixture, roleFixture, projectFixture,
+		identitySharingFixture).Txn(true)
+	rr := NewRoleResolver(tx)
+
+	isShared, err := rr.IsUserSharedWithTenant(&user1, tenantUUID2)
+
+	dieOnErr(t, err)
+	checkDeepEqual(t, true, isShared)
+}
+
+func Test_IsServiceAccountSharedWithTenant(t *testing.T) {
+	tx := runFixtures(t, tenantFixture, userFixture, serviceAccountFixture, groupFixture, roleFixture, projectFixture,
+		identitySharingFixture).Txn(true)
+	rr := NewRoleResolver(tx)
+
+	isShared, err := rr.IsServiceAccountSharedWithTenant(&sa4, tenantUUID1)
+
+	dieOnErr(t, err)
+	checkDeepEqual(t, true, isShared)
 }

--- a/vault-plugins/flant_iam/model/roleresolver_test.go
+++ b/vault-plugins/flant_iam/model/roleresolver_test.go
@@ -7,6 +7,7 @@ import (
 func Test_collectAllRolesAndRoleBindings(t *testing.T) {
 	tx := runFixtures(t, tenantFixture, userFixture, serviceAccountFixture, groupFixture, roleFixture, projectFixture,
 		roleBindingFixture).Txn(true)
+	// test for private method
 	rr := roleResolver{
 		ri:  NewRoleRepository(tx),
 		gi:  NewGroupRepository(tx),
@@ -27,6 +28,7 @@ func Test_collectAllRolesAndRoleBindings(t *testing.T) {
 func Test_collectAllRoleBindingsForUser(t *testing.T) {
 	tx := runFixtures(t, tenantFixture, userFixture, serviceAccountFixture, groupFixture, roleFixture, projectFixture,
 		roleBindingFixture).Txn(true)
+	// test for private method
 	rr := roleResolver{
 		ri:  NewRoleRepository(tx),
 		gi:  NewGroupRepository(tx),
@@ -43,11 +45,7 @@ func Test_collectAllRoleBindingsForUser(t *testing.T) {
 func Test_CheckUserForProjectScopedRole(t *testing.T) {
 	tx := runFixtures(t, tenantFixture, userFixture, serviceAccountFixture, groupFixture, roleFixture, projectFixture,
 		roleBindingFixture).Txn(true)
-	rr := roleResolver{
-		ri:  NewRoleRepository(tx),
-		gi:  NewGroupRepository(tx),
-		rbi: NewRoleBindingRepository(tx),
-	}
+	rr := NewRoleResolver(tx)
 
 	hasRole, gotParams, err := rr.CheckUserForProjectScopedRole(userUUID1, roleName1, tenantUUID1, projectUUID1)
 
@@ -60,6 +58,7 @@ func Test_CheckUserForProjectScopedRole(t *testing.T) {
 func Test_collectAllRoleBindingsForServiceAccount(t *testing.T) {
 	tx := runFixtures(t, tenantFixture, userFixture, serviceAccountFixture, groupFixture, roleFixture, projectFixture,
 		roleBindingFixture).Txn(true)
+	// test for private method
 	rr := roleResolver{
 		ri:  NewRoleRepository(tx),
 		gi:  NewGroupRepository(tx),
@@ -80,11 +79,7 @@ func Test_collectAllRoleBindingsForServiceAccount(t *testing.T) {
 func Test_CheckServiceAccountForProjectScopedRole(t *testing.T) {
 	tx := runFixtures(t, tenantFixture, userFixture, serviceAccountFixture, groupFixture, roleFixture, projectFixture,
 		roleBindingFixture).Txn(true)
-	rr := roleResolver{
-		ri:  NewRoleRepository(tx),
-		gi:  NewGroupRepository(tx),
-		rbi: NewRoleBindingRepository(tx),
-	}
+	rr := NewRoleResolver(tx)
 
 	hasRole, gotParams, err := rr.CheckServiceAccountForProjectScopedRole(serviceAccountUUID1, roleName1,
 		tenantUUID1, projectUUID1)
@@ -98,11 +93,7 @@ func Test_CheckServiceAccountForProjectScopedRole(t *testing.T) {
 func Test_CheckUserForTenantScopedRole(t *testing.T) {
 	tx := runFixtures(t, tenantFixture, userFixture, serviceAccountFixture, groupFixture, roleFixture, projectFixture,
 		roleBindingFixture).Txn(true)
-	rr := roleResolver{
-		ri:  NewRoleRepository(tx),
-		gi:  NewGroupRepository(tx),
-		rbi: NewRoleBindingRepository(tx),
-	}
+	rr := NewRoleResolver(tx)
 
 	hasRole, gotParams, err := rr.CheckUserForTenantScopedRole(userUUID2, roleName9, tenantUUID1)
 
@@ -115,11 +106,7 @@ func Test_CheckUserForTenantScopedRole(t *testing.T) {
 func Test_CheckServiceAccountForTenantScopedRole(t *testing.T) {
 	tx := runFixtures(t, tenantFixture, userFixture, serviceAccountFixture, groupFixture, roleFixture, projectFixture,
 		roleBindingFixture).Txn(true)
-	rr := roleResolver{
-		ri:  NewRoleRepository(tx),
-		gi:  NewGroupRepository(tx),
-		rbi: NewRoleBindingRepository(tx),
-	}
+	rr := NewRoleResolver(tx)
 
 	hasRole, gotParams, err := rr.CheckServiceAccountForTenantScopedRole(serviceAccountUUID2, roleName9, tenantUUID1)
 
@@ -132,11 +119,7 @@ func Test_CheckServiceAccountForTenantScopedRole(t *testing.T) {
 func Test_FindSubjectsWithProjectScopedRole(t *testing.T) {
 	tx := runFixtures(t, tenantFixture, userFixture, serviceAccountFixture, groupFixture, roleFixture, projectFixture,
 		roleBindingFixture).Txn(true)
-	rr := roleResolver{
-		ri:  NewRoleRepository(tx),
-		gi:  NewGroupRepository(tx),
-		rbi: NewRoleBindingRepository(tx),
-	}
+	rr := NewRoleResolver(tx)
 
 	users, serviceAccounts, err := rr.FindSubjectsWithProjectScopedRole(roleName1, tenantUUID1, projectUUID3)
 
@@ -148,11 +131,7 @@ func Test_FindSubjectsWithProjectScopedRole(t *testing.T) {
 func Test_FindSubjectsWithTenantScopedRole(t *testing.T) {
 	tx := runFixtures(t, tenantFixture, userFixture, serviceAccountFixture, groupFixture, roleFixture, projectFixture,
 		roleBindingFixture).Txn(true)
-	rr := roleResolver{
-		ri:  NewRoleRepository(tx),
-		gi:  NewGroupRepository(tx),
-		rbi: NewRoleBindingRepository(tx),
-	}
+	rr := NewRoleResolver(tx)
 
 	users, serviceAccounts, err := rr.FindSubjectsWithTenantScopedRole(roleName9, tenantUUID1)
 
@@ -164,11 +143,7 @@ func Test_FindSubjectsWithTenantScopedRole(t *testing.T) {
 func Test_CheckGroupForRole(t *testing.T) {
 	tx := runFixtures(t, tenantFixture, userFixture, serviceAccountFixture, groupFixture, roleFixture, projectFixture,
 		roleBindingFixture).Txn(true)
-	rr := roleResolver{
-		ri:  NewRoleRepository(tx),
-		gi:  NewGroupRepository(tx),
-		rbi: NewRoleBindingRepository(tx),
-	}
+	rr := NewRoleResolver(tx)
 
 	hasRole, err := rr.CheckGroupForRole(groupUUID2, roleName1)
 
@@ -179,11 +154,7 @@ func Test_CheckGroupForRole(t *testing.T) {
 func Test_CheckGroupForRoleNegative(t *testing.T) {
 	tx := runFixtures(t, tenantFixture, userFixture, serviceAccountFixture, groupFixture, roleFixture, projectFixture,
 		roleBindingFixture).Txn(true)
-	rr := roleResolver{
-		ri:  NewRoleRepository(tx),
-		gi:  NewGroupRepository(tx),
-		rbi: NewRoleBindingRepository(tx),
-	}
+	rr := NewRoleResolver(tx)
 
 	hasRole, err := rr.CheckGroupForRole(groupUUID2, roleName4)
 


### PR DESCRIPTION
1) Implements 
	IsUserSharedWithTenant(*User, TenantUUID) (bool, error) //  change in signature
 	IsServiceAccountSharedWithTenant(*ServiceAccount, TenantUUID) (bool, error) // change in signature
	CheckGroupForRole(GroupUUID, RoleName) (bool, error)
for RoleResolver
2) Fixtures: 
- fix users and service accounts in groups from other tenant
- make fixtures for identitySharing
3) Tests:
- for new methods
- for identitySharing
