### PR TITLE
Optimize closing Kafka consumers, improve and  move logger naming inside consturctors

### DIFF
--- a/vault-plugins/flant_gitops/backend.go
+++ b/vault-plugins/flant_gitops/backend.go
@@ -44,7 +44,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 func newBackend(conf *logical.BackendConfig) (*backend, error) {
 	b := &backend{
 		TasksManager:          tasks_manager.NewManager(),
-		AccessVaultController: client.NewVaultClientController(hclog.L),
+		AccessVaultController: client.NewVaultClientController(hclog.Default()),
 	}
 
 	b.Backend = &framework.Backend{

--- a/vault-plugins/flant_iam/backend/factory.go
+++ b/vault-plugins/flant_iam/backend/factory.go
@@ -77,7 +77,7 @@ func newBackend(conf *logical.BackendConfig) (logical.Backend, error) {
 		BackendType: logical.TypeLogical,
 	}
 
-	localLogger := conf.Logger.Named("flant_iam.newBackend")
+	localLogger := conf.Logger.Named("newBackend")
 	localLogger.Debug("started")
 	defer localLogger.Debug("exit")
 

--- a/vault-plugins/flant_iam/backend/factory.go
+++ b/vault-plugins/flant_iam/backend/factory.go
@@ -28,7 +28,9 @@ var _ logical.Factory = Factory
 
 // Factory configures and returns Mock backends
 func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
-	logger := conf.Logger.Named("flant_iam.Factory")
+	baseLogger := conf.Logger.ResetNamed("IAM")
+
+	logger := baseLogger.Named("Factory")
 	logger.Debug("started")
 	defer logger.Debug("exit")
 	if os.Getenv("DEBUG") == "true" {
@@ -39,6 +41,8 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	if conf == nil {
 		return nil, fmt.Errorf("configuration passed into backend is nil")
 	}
+
+	conf.Logger = baseLogger
 
 	b, err := newBackend(conf)
 	if err != nil {
@@ -96,21 +100,18 @@ func newBackend(conf *logical.BackendConfig) (logical.Backend, error) {
 		return nil, err
 	}
 
-	storage, err := sharedio.NewMemoryStore(schema, mb)
+	storage, err := sharedio.NewMemoryStore(schema, mb, conf.Logger)
 	if err != nil {
 		return nil, err
 	}
-	storage.SetLogger(conf.Logger)
 
 	restoreHandlers := []kafka_source.RestoreFunc{
 		jwtkafka.SelfRestoreMessage,
 	}
 
-	logger := conf.Logger.Named("IAM")
+	storage.AddKafkaSource(kafka_source.NewSelfKafkaSource(mb, restoreHandlers, conf.Logger))
 
-	storage.AddKafkaSource(kafka_source.NewSelfKafkaSource(mb, restoreHandlers, conf.Logger.Named("KafkaSourceSelf")))
-
-	storage.AddKafkaSource(jwtkafka.NewJWKSKafkaSource(mb, conf.Logger.Named("KafkaSourceJWKS")))
+	storage.AddKafkaSource(jwtkafka.NewJWKSKafkaSource(mb, conf.Logger))
 
 	err = storage.Restore()
 	if err != nil {
@@ -120,7 +121,7 @@ func newBackend(conf *logical.BackendConfig) (logical.Backend, error) {
 	// destinations
 	storage.AddKafkaDestination(kafka_destination.NewSelfKafkaDestination(mb))
 
-	storage.AddKafkaDestination(jwtkafka.NewJWKSKafkaDestination(mb, logger.Named("KafkaSourceJWKS")))
+	storage.AddKafkaDestination(jwtkafka.NewJWKSKafkaDestination(mb, conf.Logger))
 
 	replicaIter, err := storage.Txn(false).Get(model.ReplicaType, iam_repo.PK)
 	if err != nil {
@@ -149,12 +150,12 @@ func newBackend(conf *logical.BackendConfig) (logical.Backend, error) {
 	tokenController := sharedjwt.NewJwtController(
 		storage,
 		mb.GetEncryptionPublicKeyStrict,
-		logger.Named("JWT.Controller"),
+		conf.Logger,
 		time.Now,
 	)
 
-	periodicLogger := logger.Named("Periodic")
 	b.PeriodicFunc = func(ctx context.Context, request *logical.Request) error {
+		periodicLogger := conf.Logger.Named("Periodic")
 		periodicLogger.Debug("Run periodic function")
 		defer periodicLogger.Debug("Periodic function finished")
 
@@ -206,7 +207,7 @@ func newBackend(conf *logical.BackendConfig) (logical.Backend, error) {
 		rolePaths(b, storage),
 
 		replicasPaths(b, storage),
-		kafkaPaths(b, storage, logger.Named("KafkaPath")),
+		kafkaPaths(b, storage, conf.Logger),
 		identitySharingPaths(b, storage),
 
 		extension_server_access.ServerPaths(b, storage, tokenController),
@@ -214,7 +215,6 @@ func newBackend(conf *logical.BackendConfig) (logical.Backend, error) {
 
 		tokenController.ApiPaths(),
 	)
-	localLogger.Debug("normal finish")
 
 	b.Clean = func(context.Context) {
 		l := b.Logger().Named("cleanup")
@@ -225,6 +225,7 @@ func newBackend(conf *logical.BackendConfig) (logical.Backend, error) {
 		l.Info("finished")
 	}
 
+	localLogger.Debug("normal finish")
 	return b, nil
 }
 

--- a/vault-plugins/flant_iam/backend/path_kafka.go
+++ b/vault-plugins/flant_iam/backend/path_kafka.go
@@ -62,6 +62,8 @@ func kafkaPaths(b logical.Backend, storage *io.MemoryStore, logger hclog.Logger)
 }
 
 func (kb kafkaBackend) handleKafkaConfiguration(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	kb.logger.Debug("handleKafkaConfiguration started")
+	defer kb.logger.Debug("handleKafkaConfiguration exit")
 	topicName, ok := data.GetOk("self_topic_name")
 	if !ok || topicName == "" {
 		return nil, logical.CodedError(http.StatusBadRequest, "self_topic_name required")

--- a/vault-plugins/flant_iam/backend/path_kafka.go
+++ b/vault-plugins/flant_iam/backend/path_kafka.go
@@ -24,12 +24,12 @@ type kafkaBackend struct {
 	logger  hclog.Logger
 }
 
-func kafkaPaths(b logical.Backend, storage *io.MemoryStore, logger hclog.Logger) []*framework.Path {
+func kafkaPaths(b logical.Backend, storage *io.MemoryStore, parentLogger hclog.Logger) []*framework.Path {
 	bb := kafkaBackend{
 		Backend: b,
 		storage: storage,
 		broker:  storage.GetKafkaBroker(),
-		logger:  logger,
+		logger:  parentLogger.Named("KafkaPath"),
 	}
 
 	configurePath := &framework.Path{

--- a/vault-plugins/flant_iam/backend/path_plugin_replicas_test.go
+++ b/vault-plugins/flant_iam/backend/path_plugin_replicas_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/assert"
@@ -150,7 +150,7 @@ func generateBackend(t *testing.T) (logical.Backend, logical.Storage) {
 		BackendType: logical.TypeLogical,
 	}
 
-	mb, err := sharedkafka.NewMessageBroker(context.TODO(), config.StorageView, log.NewNullLogger())
+	mb, err := sharedkafka.NewMessageBroker(context.TODO(), config.StorageView, hclog.NewNullLogger())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,7 +159,7 @@ func generateBackend(t *testing.T) (logical.Backend, logical.Storage) {
 		t.Fatal(err)
 	}
 
-	storage, err := sharedio.NewMemoryStore(schema, mb)
+	storage, err := sharedio.NewMemoryStore(schema, mb, hclog.NewNullLogger())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault-plugins/flant_iam/extensions/extension_server_access/usecase/server_test.go
+++ b/vault-plugins/flant_iam/extensions/extension_server_access/usecase/server_test.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -48,7 +49,7 @@ func Test_List(t *testing.T) {
 		Identifier:  "test",
 	}
 
-	memdb, _ := io.NewMemoryStore(repo.ServerSchema(), nil)
+	memdb, _ := io.NewMemoryStore(repo.ServerSchema(), nil, hclog.NewNullLogger())
 	tx := memdb.Txn(true)
 	err := tx.Insert(ext_model.ServerType, server)
 	require.NoError(t, err)

--- a/vault-plugins/flant_iam/extensions/extension_server_access/user_extension_test.go
+++ b/vault-plugins/flant_iam/extensions/extension_server_access/user_extension_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/assert"
 
@@ -137,7 +138,7 @@ func prepareRoleBinding(t *testing.T, txn *io.MemoryStoreTxn, roleName model.Rol
 func Test_UserIncludesToGroupWithSSH(t *testing.T) {
 	schema, err := iam_repo.GetSchema()
 	dieOnErr(t, err)
-	store, err := io.NewMemoryStore(schema, nil)
+	store, err := io.NewMemoryStore(schema, nil, hclog.NewNullLogger())
 	dieOnErr(t, err)
 	txn := store.Txn(true)
 	ten := prepareTenant(t, txn)
@@ -178,7 +179,7 @@ func Test_UserIncludesToGroupWithSSH(t *testing.T) {
 func Test_UserIsAddedToRoleBindingWithSSH(t *testing.T) {
 	schema, err := iam_repo.GetSchema()
 	dieOnErr(t, err)
-	store, err := io.NewMemoryStore(schema, nil)
+	store, err := io.NewMemoryStore(schema, nil, hclog.NewNullLogger())
 	dieOnErr(t, err)
 	txn := store.Txn(true)
 	ten := prepareTenant(t, txn)
@@ -215,7 +216,7 @@ func Test_UserIsAddedToRoleBindingWithSSH(t *testing.T) {
 func Test_SSHIsAddedToRoleBinding(t *testing.T) {
 	schema, err := iam_repo.GetSchema()
 	dieOnErr(t, err)
-	store, err := io.NewMemoryStore(schema, nil)
+	store, err := io.NewMemoryStore(schema, nil, hclog.NewNullLogger())
 	dieOnErr(t, err)
 	txn := store.Txn(true)
 	ten := prepareTenant(t, txn)
@@ -256,7 +257,7 @@ func Test_SSHIsAddedToRoleBinding(t *testing.T) {
 func Test_SSHIsIncludedToRole(t *testing.T) {
 	schema, err := iam_repo.GetSchema()
 	dieOnErr(t, err)
-	store, err := io.NewMemoryStore(schema, nil)
+	store, err := io.NewMemoryStore(schema, nil, hclog.NewNullLogger())
 	dieOnErr(t, err)
 	txn := store.Txn(true)
 	ten := prepareTenant(t, txn)

--- a/vault-plugins/flant_iam/txnwatchers/role_watchers_test.go
+++ b/vault-plugins/flant_iam/txnwatchers/role_watchers_test.go
@@ -3,6 +3,7 @@ package txnwatchers
 import (
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 
 	"github.com/flant/negentropy/vault-plugins/flant_iam/model"
@@ -256,7 +257,7 @@ func getTestMemoryStorage(t *testing.T, fixtureFunc func(t *testing.T, txn *io.M
 	// Create db with some entities.
 	schema, err := repo.GetSchema()
 	require.NoError(t, err)
-	mem, err := io.NewMemoryStore(schema, nil)
+	mem, err := io.NewMemoryStore(schema, nil, hclog.NewNullLogger())
 	require.NoError(t, err)
 
 	if fixtureFunc != nil {

--- a/vault-plugins/flant_iam/usecase/testhelpers.go
+++ b/vault-plugins/flant_iam/usecase/testhelpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 
 	"github.com/flant/negentropy/vault-plugins/flant_iam/model"
@@ -14,7 +15,7 @@ import (
 func runFixtures(t *testing.T, fixtures ...func(t *testing.T, store *io.MemoryStore)) *io.MemoryStore {
 	schema, err := iam_repo.GetSchema()
 	require.NoError(t, err)
-	store, err := io.NewMemoryStore(schema, nil)
+	store, err := io.NewMemoryStore(schema, nil, hclog.NewNullLogger())
 	require.NoError(t, err)
 	for _, fixture := range fixtures {
 		fixture(t, store)

--- a/vault-plugins/flant_iam_auth/backend/path_kafka.go
+++ b/vault-plugins/flant_iam_auth/backend/path_kafka.go
@@ -76,6 +76,8 @@ func kafkaPaths(b logical.Backend, storage *sharedio.MemoryStore, logger hclog.L
 }
 
 func (kb kafkaBackend) handleKafkaConfiguration(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	kb.logger.Debug("handleKafkaConfiguration started")
+	defer kb.logger.Debug("handleKafkaConfiguration exit")
 	if len(kb.broker.GetEndpoints()) == 0 {
 		rr := logical.ErrorResponse("kafka connection is not configured. Run /kafka/configure_access first")
 		return logical.RespondWithStatusCode(rr, req, http.StatusPreconditionFailed)

--- a/vault-plugins/flant_iam_auth/backend/path_kafka.go
+++ b/vault-plugins/flant_iam_auth/backend/path_kafka.go
@@ -25,12 +25,12 @@ type kafkaBackend struct {
 	logger  hclog.Logger
 }
 
-func kafkaPaths(b logical.Backend, storage *sharedio.MemoryStore, logger hclog.Logger) []*framework.Path {
+func kafkaPaths(b logical.Backend, storage *sharedio.MemoryStore, parentLogger hclog.Logger) []*framework.Path {
 	bb := kafkaBackend{
 		Backend: b,
 		storage: storage,
 		broker:  storage.GetKafkaBroker(),
-		logger:  logger,
+		logger:  parentLogger.Named("KafkaBackend"),
 	}
 
 	configurePath := &framework.Path{

--- a/vault-plugins/flant_iam_auth/extensions/extension_server_access/types_test.go
+++ b/vault-plugins/flant_iam_auth/extensions/extension_server_access/types_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/flant/negentropy/vault-plugins/flant_iam/extensions/extension_server_access/model"
@@ -80,7 +81,7 @@ func TestUserToPosix(t *testing.T) {
 		Identifier: "tenant2",
 	}
 
-	st, _ := io.NewMemoryStore(iam_repo.TenantSchema(), nil)
+	st, _ := io.NewMemoryStore(iam_repo.TenantSchema(), nil, hclog.NewNullLogger())
 	tx := st.Txn(true)
 	_ = tx.Insert(iam_model.TenantType, tenant2)
 	_ = tx.Commit()

--- a/vault-plugins/flant_iam_auth/io/downstream/vault/entities.go
+++ b/vault-plugins/flant_iam_auth/io/downstream/vault/entities.go
@@ -27,11 +27,11 @@ type VaultEntityDownstreamApi struct {
 	logger              log.Logger
 }
 
-func NewVaultEntityDownstreamApi(getClient io.BackoffClientGetter, mountAccessorGetter *MountAccessorGetter, logger log.Logger) *VaultEntityDownstreamApi {
+func NewVaultEntityDownstreamApi(getClient io.BackoffClientGetter, mountAccessorGetter *MountAccessorGetter, parenatLogger log.Logger) *VaultEntityDownstreamApi {
 	return &VaultEntityDownstreamApi{
 		getClient:           getClient,
 		mountAccessorGetter: mountAccessorGetter,
-		logger:              logger,
+		logger:              parenatLogger.Named("VaultIdentityClient"),
 	}
 }
 

--- a/vault-plugins/flant_iam_auth/io/downstream/vault/entities_test.go
+++ b/vault-plugins/flant_iam_auth/io/downstream/vault/entities_test.go
@@ -47,7 +47,7 @@ func getDownStreamApi() (*VaultEntityDownstreamApi, *io.MemoryStore, *api.Client
 		return nil, nil, nil, err
 	}
 
-	storage, err := io.NewMemoryStore(schema, mb)
+	storage, err := io.NewMemoryStore(schema, mb, hclog.NewNullLogger())
 
 	getClient := func() (*api.Client, error) {
 		return client, nil

--- a/vault-plugins/flant_iam_auth/io/kafka_destination/multipass_generation.go
+++ b/vault-plugins/flant_iam_auth/io/kafka_destination/multipass_generation.go
@@ -22,10 +22,10 @@ type MultipassGenerationKafkaDestination struct {
 	logger hclog.Logger
 }
 
-func NewMultipassGenerationKafkaDestination(mb *kafka.MessageBroker, logger hclog.Logger) *MultipassGenerationKafkaDestination {
+func NewMultipassGenerationKafkaDestination(mb *kafka.MessageBroker, parentLogger hclog.Logger) *MultipassGenerationKafkaDestination {
 	return &MultipassGenerationKafkaDestination{
 		mb:     mb,
-		logger: logger,
+		logger: parentLogger.Named("KafkaDestinationMultipassGen"),
 	}
 }
 

--- a/vault-plugins/flant_iam_auth/io/kafka_handlers/root/object_handler.go
+++ b/vault-plugins/flant_iam_auth/io/kafka_handlers/root/object_handler.go
@@ -20,13 +20,13 @@ type ObjectHandler struct {
 	logger hclog.Logger
 }
 
-func NewObjectHandler(txn *io.MemoryStoreTxn, logger hclog.Logger) *ObjectHandler {
+func NewObjectHandler(txn *io.MemoryStoreTxn, parentLogger hclog.Logger) *ObjectHandler {
 	return &ObjectHandler{
 		entityRepo:       repo2.NewEntityRepo(txn),
 		eaRepo:           repo2.NewEntityAliasRepo(txn),
 		authSourceRepo:   repo2.NewAuthSourceRepo(txn),
 		multipassGenRepo: repo2.NewMultipassGenerationNumberRepository(txn),
-		logger:           logger,
+		logger:           parentLogger.Named("RootSourceHandler"),
 	}
 }
 

--- a/vault-plugins/flant_iam_auth/io/kafka_handlers/self/object_handler.go
+++ b/vault-plugins/flant_iam_auth/io/kafka_handlers/self/object_handler.go
@@ -25,7 +25,7 @@ type ObjectHandler struct {
 	logger hclog.Logger
 }
 
-func NewObjectHandler(memStore *io.MemoryStore, txn *io.MemoryStoreTxn, api *vault.VaultEntityDownstreamApi, logger hclog.Logger) *ObjectHandler {
+func NewObjectHandler(memStore *io.MemoryStore, txn *io.MemoryStoreTxn, api *vault.VaultEntityDownstreamApi, parentLogger hclog.Logger) *ObjectHandler {
 	return &ObjectHandler{
 		eaRepo:     repo.NewEntityAliasRepo(txn),
 		entityRepo: repo.NewEntityRepo(txn),
@@ -34,7 +34,7 @@ func NewObjectHandler(memStore *io.MemoryStore, txn *io.MemoryStoreTxn, api *vau
 		memStore:   memStore,
 		txn:        txn,
 		downstream: api,
-		logger:     logger,
+		logger:     parentLogger.Named("SelfSourceHandler"),
 	}
 }
 

--- a/vault-plugins/flant_iam_auth/io/utils/tests/storage.go
+++ b/vault-plugins/flant_iam_auth/io/utils/tests/storage.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/require"
 
@@ -16,13 +16,13 @@ import (
 func CreateTestStorage(t *testing.T) *io.MemoryStore {
 	storageView := &logical.InmemStorage{}
 
-	mb, err := sharedkafka.NewMessageBroker(context.TODO(), storageView, log.NewNullLogger())
+	mb, err := sharedkafka.NewMessageBroker(context.TODO(), storageView, hclog.NewNullLogger())
 	require.NoError(t, err)
 
 	schema, err := repo.GetSchema()
 	require.NoError(t, err)
 
-	storage, err := io.NewMemoryStore(schema, mb)
+	storage, err := io.NewMemoryStore(schema, mb, hclog.NewNullLogger())
 	require.NoError(t, err)
 
 	return storage

--- a/vault-plugins/flant_iam_auth/usecase/authn/factory/factory.go
+++ b/vault-plugins/flant_iam_auth/usecase/authn/factory/factory.go
@@ -27,9 +27,9 @@ type AuthenticatorFactory struct {
 	validators map[string]*hcjwt.Validator
 }
 
-func NewAuthenticatorFactory(jwtController *njwt.Controller, logger hclog.Logger) *AuthenticatorFactory {
+func NewAuthenticatorFactory(jwtController *njwt.Controller, parentLogger hclog.Logger) *AuthenticatorFactory {
 	return &AuthenticatorFactory{
-		logger:        logger,
+		logger:        parentLogger.Named("Login"),
 		jwtController: jwtController,
 		validators:    map[string]*hcjwt.Validator{},
 	}

--- a/vault-plugins/shared/client/access_client.go
+++ b/vault-plugins/shared/client/access_client.go
@@ -15,7 +15,7 @@ type accessClient struct {
 	rolePrefix  string
 }
 
-func newAccessClient(apiClient *api.Client, accessConf *vaultAccessConfig, logger hclog.Logger) *accessClient {
+func newAccessClient(apiClient *api.Client, accessConf *vaultAccessConfig, parentLogger hclog.Logger) *accessClient {
 	rolePrefix := fmt.Sprintf("%s/role/%s", accessConf.ApproleMountPoint, accessConf.RoleName)
 
 	return &accessClient{
@@ -23,7 +23,7 @@ func newAccessClient(apiClient *api.Client, accessConf *vaultAccessConfig, logge
 		conf:        accessConf,
 		mountPrefix: accessConf.ApproleMountPoint,
 		rolePrefix:  rolePrefix,
-		logger:      logger,
+		logger:      parentLogger.Named("accessClient"),
 	}
 }
 

--- a/vault-plugins/shared/client/examples/backend.go
+++ b/vault-plugins/shared/client/examples/backend.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 
@@ -28,7 +28,7 @@ type exampleBackend struct {
 
 func backend() *exampleBackend {
 	b := new(exampleBackend)
-	b.accessVaultController = client.NewVaultClientController(log.L)
+	b.accessVaultController = client.NewVaultClientController(hclog.Default())
 
 	b.Backend = &framework.Backend{
 		BackendType:  logical.TypeCredential,

--- a/vault-plugins/shared/io/hook_test.go
+++ b/vault-plugins/shared/io/hook_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -11,7 +12,7 @@ import (
 
 func TestHooks(t *testing.T) {
 	t.Run("test insert", func(t *testing.T) {
-		mem, err := NewMemoryStore(testSchema(), nil)
+		mem, err := NewMemoryStore(testSchema(), nil, hclog.NewNullLogger())
 		require.NoError(t, err)
 
 		hook := ObjectHook{

--- a/vault-plugins/shared/io/store.go
+++ b/vault-plugins/shared/io/store.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"sync"
 
-	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
 
 	"github.com/flant/negentropy/vault-plugins/shared/kafka"
@@ -50,7 +50,7 @@ type MemoryStore struct {
 	hooks     map[string][]ObjectHook // by objectType
 	// vaultStorage      VaultStorage
 	// downstreamApis    []DownstreamApi
-	logger log.Logger
+	logger hclog.Logger
 }
 
 type MemoryStoreTxn struct {
@@ -191,7 +191,7 @@ func (mst *MemoryStoreTxn) Abort() {
 	mst.Txn.Abort()
 }
 
-func NewMemoryStore(schema *memdb.DBSchema, conn *kafka.MessageBroker) (*MemoryStore, error) {
+func NewMemoryStore(schema *memdb.DBSchema, conn *kafka.MessageBroker, parentLogger hclog.Logger) (*MemoryStore, error) {
 	db, err := memdb.NewMemDB(schema)
 	if err != nil {
 		return nil, err
@@ -207,12 +207,8 @@ func NewMemoryStore(schema *memdb.DBSchema, conn *kafka.MessageBroker) (*MemoryS
 		make(map[string]KafkaDestination),
 		sync.Mutex{},
 		make(map[string][]ObjectHook),
-		log.New(nil),
+		parentLogger.Named("MemStore"),
 	}, nil
-}
-
-func (ms *MemoryStore) SetLogger(l log.Logger) {
-	ms.logger = l
 }
 
 func (ms *MemoryStore) AddKafkaSource(s KafkaSource) {

--- a/vault-plugins/shared/io/store.go
+++ b/vault-plugins/shared/io/store.go
@@ -20,8 +20,10 @@ type KafkaSource interface {
 	// Name returns topic name
 	Name() string
 	// Restore gets data from topic and store it to txn
+	// can't call it after calling Run
 	Restore(txn *memdb.Txn) error
 	// Run starts infinite loop processing incoming messages, will returns after using Stop
+	// can call it once
 	Run(ms *MemoryStore)
 	// Stop finish running infinite loop, if used before Run, will do nothing
 	Stop()

--- a/vault-plugins/shared/io/store.go
+++ b/vault-plugins/shared/io/store.go
@@ -20,10 +20,10 @@ type KafkaSource interface {
 	// Name returns topic name
 	Name() string
 	// Restore gets data from topic and store it to txn
-	// can't call it after calling Run
+	// don't call it after calling Run TODO fix it
 	Restore(txn *memdb.Txn) error
 	// Run starts infinite loop processing incoming messages, will returns after using Stop
-	// can call it once
+	// can call it once TODO fix it
 	Run(ms *MemoryStore)
 	// Stop finish running infinite loop, if used before Run, will do nothing
 	Stop()

--- a/vault-plugins/shared/jwt/controller.go
+++ b/vault-plugins/shared/jwt/controller.go
@@ -19,8 +19,8 @@ type Controller struct {
 	backend *backend.Backend
 }
 
-func NewJwtController(storage *sharedio.MemoryStore, idGetter func() (string, error), logger hclog.Logger, now func() time.Time) *Controller {
-	deps := usecase.NewDeps(idGetter, logger, now)
+func NewJwtController(storage *sharedio.MemoryStore, idGetter func() (string, error), parentLogger hclog.Logger, now func() time.Time) *Controller {
+	deps := usecase.NewDeps(idGetter, parentLogger.Named("JWT.Controller"), now)
 	b := backend.NewBackend(storage, deps)
 	return &Controller{
 		deps:    deps,

--- a/vault-plugins/shared/jwt/kafka/jwks_destination.go
+++ b/vault-plugins/shared/jwt/kafka/jwks_destination.go
@@ -21,10 +21,10 @@ type JWKSKafkaDestination struct {
 	logger hclog.Logger
 }
 
-func NewJWKSKafkaDestination(mb *kafka.MessageBroker, logger hclog.Logger) *JWKSKafkaDestination {
+func NewJWKSKafkaDestination(mb *kafka.MessageBroker, parentLogger hclog.Logger) *JWKSKafkaDestination {
 	return &JWKSKafkaDestination{
 		mb:     mb,
-		logger: logger,
+		logger: parentLogger.Named("KafkaSourceJWKS"),
 	}
 }
 

--- a/vault-plugins/shared/jwt/kafka/self_support_test.go
+++ b/vault-plugins/shared/jwt/kafka/self_support_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 
 	"github.com/flant/negentropy/vault-plugins/shared/io"
@@ -12,7 +13,7 @@ import (
 
 func Test_SelfRestoreMessage_JWTConfigType(t *testing.T) {
 	schema := model.ConfigSchema()
-	store, err := io.NewMemoryStore(schema, nil)
+	store, err := io.NewMemoryStore(schema, nil, hclog.NewNullLogger())
 	require.NoError(t, err)
 	txn := store.Txn(true)
 

--- a/vault-plugins/shared/jwt/test/utils.go
+++ b/vault-plugins/shared/jwt/test/utils.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/require"
@@ -16,11 +16,11 @@ import (
 )
 
 func GetStorage(t *testing.T, config *logical.BackendConfig) *sharedio.MemoryStore {
-	mb, err := kafka.NewMessageBroker(context.TODO(), config.StorageView, log.NewNullLogger())
+	mb, err := kafka.NewMessageBroker(context.TODO(), config.StorageView, hclog.NewNullLogger())
 	require.NoError(t, err)
 	schema, err := model.GetSchema(false)
 	require.NoError(t, err)
-	storage, err := sharedio.NewMemoryStore(schema, mb)
+	storage, err := sharedio.NewMemoryStore(schema, mb, hclog.NewNullLogger())
 
 	return storage
 }
@@ -30,7 +30,7 @@ func PrepareBackend(t *testing.T) *logical.BackendConfig {
 	maxLeaseTTLVal := time.Hour * 24
 
 	config := &logical.BackendConfig{
-		Logger: logging.NewVaultLogger(log.Trace),
+		Logger: logging.NewVaultLogger(hclog.Trace),
 
 		System: &logical.StaticSystemView{
 			DefaultLeaseTTLVal: defaultLeaseTTLVal,

--- a/vault-plugins/shared/kafka/msg.go
+++ b/vault-plugins/shared/kafka/msg.go
@@ -162,7 +162,7 @@ func LastAndEdgeOffsetsByRunConsumer(runConsumer *kafka.Consumer, newConsumer *k
 		Offset:    kafka.OffsetTail(2),
 	}
 	err = newConsumer.Assign([]kafka.TopicPartition{tp})
-	defer newConsumer.Unassign()
+	defer newConsumer.Unassign() // nolint:errcheck
 	if err != nil {
 		return 0, 0, 0, fmt.Errorf("assigning last message: %w", err)
 	}

--- a/vault-plugins/shared/kafka/msg.go
+++ b/vault-plugins/shared/kafka/msg.go
@@ -56,9 +56,10 @@ func RunRestorationLoop(newConsumer, runConsumer *kafka.Consumer, topicName stri
 	defer logger.Debug("exit")
 
 	var lastOffset, edgeOffset int64
+	var partition int32
 	var err error
 	if runConsumer != nil {
-		lastOffset, edgeOffset, err = LastAndEdgeOffsetsByRunConsumer(runConsumer, topicName)
+		lastOffset, edgeOffset, partition, err = LastAndEdgeOffsetsByRunConsumer(runConsumer, newConsumer, topicName)
 		if err != nil {
 			return fmt.Errorf("getting offset by RunConsumer:%w", err)
 		}
@@ -67,19 +68,21 @@ func RunRestorationLoop(newConsumer, runConsumer *kafka.Consumer, topicName stri
 			return fmt.Errorf("subscribing newConsumer:%w", err)
 		}
 	} else {
-		lastOffset, err = LastOffsetByNewConsumer(newConsumer, topicName)
+		lastOffset, partition, err = LastOffsetByNewConsumer(newConsumer, topicName)
 		if err != nil {
 			return fmt.Errorf("getting offset by newConsumer:%w", err)
 		}
-		err = resetConsumerToBeginning(newConsumer, topicName)
-		if err != nil {
-			return err
-		}
+
 	}
 
 	if lastOffset == 0 && edgeOffset == 0 {
 		logger.Debug("normal finish: no messages", "topicName", topicName)
 		return nil
+	}
+
+	err = setNewConsumerToBeginning(newConsumer, topicName, partition)
+	if err != nil {
+		return err
 	}
 
 	c := newConsumer.Events()
@@ -110,50 +113,51 @@ func RunRestorationLoop(newConsumer, runConsumer *kafka.Consumer, topicName stri
 	}
 }
 
-func getNextWritingOffsetByMetaData(consumer *kafka.Consumer, topicName string) (int64, error) {
+// returns metadata & last offset in topic
+func getNextWritingOffsetByMetaData(consumer *kafka.Consumer, topicName string) (*kafka.Metadata, int64, error) {
 	edgeOffset := int64(0)
 	meta, err := consumer.GetMetadata(&topicName, false, -1)
 	if err != nil {
-		return 0, err
+		return nil, 0, err
 	}
 
 	topicMeta := meta.Topics[topicName]
 	for _, partition := range topicMeta.Partitions {
 		_, lastPartitionOffset, err := consumer.QueryWatermarkOffsets(topicName, partition.ID, -1)
 		if err != nil {
-			return 0, err
+			return nil, 0, err
 		}
 		if lastPartitionOffset > edgeOffset {
 			edgeOffset = lastPartitionOffset
 		}
 	}
-	return edgeOffset, nil
+	return meta, edgeOffset, nil
 }
 
-func LastAndEdgeOffsetsByRunConsumer(consumer *kafka.Consumer, topicName string) (lastOffsetForRestoring int64, edgeOffset int64, err error) {
-	t, err := getNextWritingOffsetByMetaData(consumer, topicName)
+// LastAndEdgeOffsetsByRunConsumer
+// note: works only for 1 partition
+func LastAndEdgeOffsetsByRunConsumer(runConsumer *kafka.Consumer, newConsumer *kafka.Consumer,
+	topicName string) (lastOffsetForRestoring int64, edgeOffset int64, partition int32, err error) {
+	metaData, t, err := getNextWritingOffsetByMetaData(runConsumer, topicName)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
+	partition = metaData.Topics[topicName].Partitions[0].ID
 	if t == 0 {
-		return 0, 0, nil
-	}
-	metaData, err := consumer.GetMetadata(&topicName, false, 1000)
-	if err != nil {
-		return 0, 0, err
+		return 0, 0, partition, nil
 	}
 	tp := kafka.TopicPartition{
 		Topic:     &topicName,
-		Partition: metaData.Topics[topicName].Partitions[0].ID,
+		Partition: partition,
 	}
 
-	offsets, err := consumer.Committed([]kafka.TopicPartition{tp}, 10000)
+	offsets, err := runConsumer.Committed([]kafka.TopicPartition{tp}, 10000)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
 	nextOffset := offsets[0].Offset
 	if nextOffset < 0 {
-		return 0, 0, nil
+		return 0, 0, partition, nil
 	}
 
 	tp = kafka.TopicPartition{
@@ -161,51 +165,49 @@ func LastAndEdgeOffsetsByRunConsumer(consumer *kafka.Consumer, topicName string)
 		Partition: metaData.Topics[topicName].Partitions[0].ID,
 		Offset:    kafka.OffsetTail(2),
 	}
-	err = consumer.Assign([]kafka.TopicPartition{tp})
-
+	err = newConsumer.Assign([]kafka.TopicPartition{tp})
+	defer newConsumer.Unassign()
 	if err != nil {
-		return 0, 0, fmt.Errorf("assigning last message: %w", err)
+		return 0, 0, 0, fmt.Errorf("assigning last message: %w", err)
 	}
-	ch := consumer.Events()
+	ch := newConsumer.Events()
 	var msg *kafka.Message
 	for msg == nil {
 		ev := <-ch
+
 		switch e := ev.(type) {
 		case *kafka.Message:
 			msg = e
 		default:
-			return 0, 0, fmt.Errorf("recieve not handled event %s", e.String())
+			return 0, 0, 0, fmt.Errorf("recieve not handled event %s", e.String())
 		}
 	}
 
 	lastOffsetAtTopic := msg.TopicPartition.Offset
 	if nextOffset > lastOffsetAtTopic {
-		return int64(lastOffsetAtTopic), 0, nil
+		return int64(lastOffsetAtTopic), 0, partition, nil
 	}
-	return 0, int64(nextOffset), nil
+	return 0, int64(nextOffset), partition, nil
 }
 
-func LastOffsetByNewConsumer(consumer *kafka.Consumer, topicName string) (lastOffsetForRestoring int64, err error) {
-	t, err := getNextWritingOffsetByMetaData(consumer, topicName)
+func LastOffsetByNewConsumer(consumer *kafka.Consumer, topicName string) (lastOffsetForRestoring int64, partition int32, err error) {
+	metaData, t, err := getNextWritingOffsetByMetaData(consumer, topicName)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
+	partition = metaData.Topics[topicName].Partitions[0].ID
 	if t == 0 {
-		return 0, nil
-	}
-	metaData, err := consumer.GetMetadata(&topicName, false, 1000)
-	if err != nil {
-		return 0, err
+		return 0, partition, nil
 	}
 
 	tp := kafka.TopicPartition{
 		Topic:     &topicName,
-		Partition: metaData.Topics[topicName].Partitions[0].ID,
+		Partition: partition,
 		Offset:    kafka.OffsetTail(2),
 	}
 	err = consumer.Assign([]kafka.TopicPartition{tp})
 	if err != nil {
-		return 0, fmt.Errorf("assigning last message: %w", err)
+		return 0, 0, fmt.Errorf("assigning last message: %w", err)
 	}
 	ch := consumer.Events()
 	var msg *kafka.Message
@@ -214,23 +216,19 @@ func LastOffsetByNewConsumer(consumer *kafka.Consumer, topicName string) (lastOf
 	case *kafka.Message:
 		msg = e
 	default:
-		return 0, fmt.Errorf("recieve not handled event %s", e.String())
+		// do nothing
 	}
 	lastOffsetAtTopic := msg.TopicPartition.Offset
-	return int64(lastOffsetAtTopic), nil
+	return int64(lastOffsetAtTopic), partition, nil
 }
 
-func resetConsumerToBeginning(consumer *kafka.Consumer, topicName string) error {
-	metaData, err := consumer.GetMetadata(&topicName, false, 1000)
-	if err != nil {
-		return err
-	}
+func setNewConsumerToBeginning(consumer *kafka.Consumer, topicName string, partition int32) error {
 	tp := kafka.TopicPartition{
 		Topic:     &topicName,
-		Partition: metaData.Topics[topicName].Partitions[0].ID,
+		Partition: partition,
 		Offset:    kafka.OffsetBeginning,
 	}
-	err = consumer.Assign([]kafka.TopicPartition{tp})
+	err := consumer.Assign([]kafka.TopicPartition{tp})
 	if err != nil {
 		return fmt.Errorf("assigning first message: %w", err)
 	}

--- a/vault-plugins/shared/kafka/msg_test.go
+++ b/vault-plugins/shared/kafka/msg_test.go
@@ -34,7 +34,7 @@ var testcases = []testCase{
 	{10, 0, 0, 0, "reading from not empty topic, without main reading before"},
 	{10, 5, 0, 5, "reading from topic, with partial main reading before"},
 	{10, 10, 9, 0, "reading from topic, with full main reading before"},
-	//{1000, 1000, 999, 0, "reading from topic, with full main reading before"},
+	// {1000, 1000, 999, 0, "reading from topic, with full main reading before"},
 }
 
 func TestTableForLastAndEdgeOffsets(t *testing.T) {
@@ -124,7 +124,7 @@ func TestTableForLastAndEdgeOffsets(t *testing.T) {
 			return c
 		})
 		if testcase.countMainRead > 0 {
-			fmt.Printf("restoration read for %d messages, spent %s\n", testcase.countMainRead, time.Now().Sub(start).String())
+			fmt.Printf("restoration read for %d messages, spent %s\n", testcase.countMainRead, time.Since(start).String())
 		}
 		assert.NoError(t, err, testcase.description+":restore reading  messages")
 

--- a/vault-plugins/shared/kafka/msg_test.go
+++ b/vault-plugins/shared/kafka/msg_test.go
@@ -165,6 +165,43 @@ func TestTableForLastAndEdgeOffsets(t *testing.T) {
 	}
 }
 
+func TestLastOffsetByNewConsumer(t *testing.T) {
+	if os.Getenv("KAFKA_ON_LOCALHOST") != "true" {
+		t.Skip("manual or integration test. Requires kafka")
+	}
+	DoNotEncrypt = true // TODO remove
+	broker := messageBroker(t)
+	topic := broker.PluginConfig.SelfTopicName
+	err := broker.CreateTopic(context.TODO(), topic, nil)
+	assert.NoError(t, err, "creating topic")
+	fillTopic(t, broker, 15)
+
+	newConsumer := broker.GetRestorationReader()
+	l, p, err := LastOffsetByNewConsumer(newConsumer, topic)
+
+	require.NoError(t, err, "LastOffsetByNewConsumer")
+	assert.Equal(t, int64(14), l)
+	assert.Equal(t, int32(0), p)
+}
+
+func TestLastOffsetByNewConsumerEmptyTopic(t *testing.T) {
+	if os.Getenv("KAFKA_ON_LOCALHOST") != "true" {
+		t.Skip("manual or integration test. Requires kafka")
+	}
+	DoNotEncrypt = true // TODO remove
+	broker := messageBroker(t)
+	topic := broker.PluginConfig.SelfTopicName
+	err := broker.CreateTopic(context.TODO(), topic, nil)
+	assert.NoError(t, err, "creating topic")
+
+	newConsumer := broker.GetRestorationReader()
+	l, p, err := LastOffsetByNewConsumer(newConsumer, topic)
+
+	require.NoError(t, err, "LastOffsetByNewConsumer")
+	assert.Equal(t, int64(0), l)
+	assert.Equal(t, int32(0), p)
+}
+
 func tryWithTimeOut(seconds int, runner func() <-chan struct{}) error {
 	timer := time.NewTimer(time.Duration(seconds) * time.Second)
 	c := runner()

--- a/vault-plugins/shared/kafka/msg_test.go
+++ b/vault-plugins/shared/kafka/msg_test.go
@@ -34,13 +34,15 @@ var testcases = []testCase{
 	{10, 0, 0, 0, "reading from not empty topic, without main reading before"},
 	{10, 5, 0, 5, "reading from topic, with partial main reading before"},
 	{10, 10, 9, 0, "reading from topic, with full main reading before"},
+	//{1000, 1000, 999, 0, "reading from topic, with full main reading before"},
 }
 
-func TestTable(t *testing.T) {
+func TestTableForLastAndEdgeOffsets(t *testing.T) {
 	if os.Getenv("KAFKA_ON_LOCALHOST") != "true" {
 		t.Skip("manual or integration test. Requires kafka")
 	}
 	DoNotEncrypt = true // TODO remove
+
 	for i := range testcases {
 		testcase := testcases[i]
 		fmt.Printf("====%#v===\n", testcase)
@@ -69,16 +71,25 @@ func TestTable(t *testing.T) {
 		assert.NoError(t, err, testcase.description+":filling messages")
 		mainReadingGroupID := "group" + strings.ReplaceAll(time.Now().String()[11:19], ":", "_")
 
-		err = tryWithTimeOut(30, func() <-chan struct{} {
+		timeout := 30
+		if testcase.countMainRead > 100 {
+			timeout = 100
+		}
+		err = tryWithTimeOut(timeout, func() <-chan struct{} {
 			c := make(chan struct{})
 			go func() {
-				mainRead(t, broker, topic, mainReadingGroupID, testcase.countMainRead)
+				mainConsumer := broker.GetSubscribedRunConsumer(mainReadingGroupID, topic)
+				mainRead(t, broker, mainConsumer, testcase.countMainRead)
+				go func() {
+					mainConsumer.Close()
+				}()
 				c <- struct{}{}
 			}()
 			return c
 		})
 		assert.NoError(t, err, testcase.description+":main reading messages")
 
+		start := time.Now()
 		messageCounter := int64(0)
 		maxMessageCounter := testcase.countMainRead
 		err = tryWithTimeOut(50, func() <-chan struct{} {
@@ -104,26 +115,30 @@ func TestTable(t *testing.T) {
 					t.Errorf("expected last read:%d, got:%d", maxMessageCounter, messageCounter)
 				}
 				assert.NoError(t, err, testcase.description+":calling  RunRestorationLoop")
-				newConsumer.Close()
-				runConsumer.Close()
+				go func() {
+					newConsumer.Close()
+					runConsumer.Close()
+				}()
 				c <- struct{}{}
 			}()
 			return c
 		})
-
+		if testcase.countMainRead > 0 {
+			fmt.Printf("restoration read for %d messages, spent %s\n", testcase.countMainRead, time.Now().Sub(start).String())
+		}
 		assert.NoError(t, err, testcase.description+":restore reading  messages")
 
 		err = tryWithTimeOut(50, func() <-chan struct{} {
 			c := make(chan struct{})
 			go func() {
 				runConsumer := broker.GetUnsubscribedRunConsumer(mainReadingGroupID)
-				lastOffset, edgeOffset, err := LastAndEdgeOffsetsByRunConsumer(runConsumer, topic)
+				newConsumer := broker.GetRestorationReader()
+				lastOffset, edgeOffset, _, err := LastAndEdgeOffsetsByRunConsumer(runConsumer, newConsumer, topic)
 				assert.NoError(t, err, testcase.description+":call LastAndEdgeOffsetsByRunConsumers")
 				assert.Equal(t, testcase.lastOffset, lastOffset)
 				assert.Equal(t, testcase.edgeOffset, edgeOffset)
 
-				newConsumer := broker.GetRestorationReader()
-				lastOffsetAtTopic, err := LastOffsetByNewConsumer(newConsumer, topic)
+				lastOffsetAtTopic, _, err := LastOffsetByNewConsumer(newConsumer, topic)
 				assert.NoError(t, err, testcase.description+":call LastAndEdgeOffsetsByRunConsumers")
 				if testcase.countFilling == 0 {
 					assert.Equal(t, testcase.countFilling, lastOffsetAtTopic)
@@ -131,7 +146,10 @@ func TestTable(t *testing.T) {
 					assert.Equal(t, testcase.countFilling-1, lastOffsetAtTopic)
 				}
 				c <- struct{}{}
-				runConsumer.Close()
+				go func() {
+					runConsumer.Close()
+					newConsumer.Close()
+				}()
 			}()
 			return c
 		})
@@ -176,8 +194,7 @@ func fillTopic(t *testing.T, mb *MessageBroker, n int64) {
 	}
 }
 
-func mainRead(t *testing.T, mb *MessageBroker, topic string, mainReadingGroupID string, n int64) {
-	mainConsumer := mb.GetSubscribedRunConsumer(mainReadingGroupID, topic)
+func mainRead(t *testing.T, mb *MessageBroker, mainConsumer *kafka.Consumer, n int64) {
 	ch := mainConsumer.Events()
 	counter := 0
 	for counter < int(n) {
@@ -186,11 +203,13 @@ func mainRead(t *testing.T, mb *MessageBroker, topic string, mainReadingGroupID 
 		switch e := ev.(type) {
 		case *kafka.Message:
 			msg = e
-			_, err := mainConsumer.CommitMessage(msg)
+			source, err := NewSourceInputMessage(mainConsumer, msg.TopicPartition)
 			if err != nil {
-				t.Errorf("unexpected error:%s", err.Error())
-				return
+				panic(err)
 			}
+
+			err = mb.SendMessages(nil, source)
+			require.NoError(t, err)
 			if string(msg.Value) != fmt.Sprintf("%d", counter) {
 				t.Errorf("expected:%d, got:%s", counter, string(msg.Value))
 				return
@@ -200,9 +219,7 @@ func mainRead(t *testing.T, mb *MessageBroker, topic string, mainReadingGroupID 
 			t.Errorf("receive not handled event %s", e.String())
 			return
 		}
-		// fmt.Printf("Message on %s: %s\n", msg.TopicPartition, string(msg.Value))
 	}
-	mainConsumer.Close()
 }
 
 func messageBroker(t *testing.T) *MessageBroker {


### PR DESCRIPTION
1) Move closing Kafka consumers into separate goroutines, it decreases starting time from 1m to 10s  
2) Make loggers names short and move naming to constructors 
3) Minor refactoring