### PR TITLE
BUG restoration corner cases

### DIFF
--- a/vault-plugins/shared/io/store.go
+++ b/vault-plugins/shared/io/store.go
@@ -343,7 +343,7 @@ func (ms *MemoryStore) Restore() error {
 		ms.logger.Warn("Kafka is not configured. Skipping restore")
 		return nil
 	}
-	txn := ms.MemDB.Txn(true)
+	txn := ms.MemDB.Txn(true).WithSkippingInsertForeignKeysCheck() // turn off checking due to possible compaction problems and restoring items with archived relations
 	ms.kafkaMutex.RLock()
 	defer ms.kafkaMutex.RUnlock()
 	for _, ks := range ms.kafkaSources {


### PR DESCRIPTION
Due to
1) checking foreignKeys relations for inserted items among not deleted 
2) kafka compaction
3) deleting some items

rollback 1+3 or 1+2 can lead to attempt to insert record related to deleted or either not created item.

Solution - create special Transaction for restoration procedure - in this transaction foreignKeys are not checked